### PR TITLE
feat(toggle): Implement `wl status`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,45 @@
+mod nmcli;
+
+use std::{error, fmt, io};
+
+#[derive(Debug)]
+pub enum Error {
+    CannotGetActiveConnections(io::Error),
+    CannotGetWifiStatus(io::Error),
+}
+
+impl error::Error for Error {}
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "will be implemented")
+    }
+}
+
+pub fn toggle() -> Result<(), Error> {
+    todo!()
+}
+
+pub fn status() -> Result<(), Error> {
+    let active_conns = nmcli::get_active_connections()
+        .map_err(Error::CannotGetActiveConnections)?
+        .join(", ");
+
+    let wifi_status = nmcli::get_wifi_status().map_err(Error::CannotGetWifiStatus)?;
+
+    println!("wifi: {}", wifi_status);
+    println!("connected networks: {}", active_conns);
+
+    Ok(())
+}
+
+pub fn connect() -> Result<(), Error> {
+    todo!()
+}
+
+pub fn scan() -> Result<(), Error> {
+    todo!()
+}
+
+pub fn disconnect() -> Result<(), Error> {
+    todo!()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,30 @@
 use clap::{Parser, Subcommand};
+use std::{error, process::ExitCode};
 
-fn main() {
-    run().unwrap()
+// TODO: add err handling and proper exit codes.
+fn main() -> ExitCode {
+    match run() {
+        Ok(_) => ExitCode::SUCCESS,
+        Err(_) => ExitCode::FAILURE,
+    }
 }
 
-fn run() -> Result<(), ()> {
+fn run() -> Result<(), Box<dyn error::Error>> {
     let args = Args::parse();
 
-    println!("{:?}", args);
+    let wl_cmd = args.wl_command.unwrap_or(WlCommand::Status);
+    match wl_cmd {
+        WlCommand::Status => wl::status(),
+        WlCommand::Toggle => wl::toggle(),
+        WlCommand::Scan(scan_args) => wl::scan(),
+        WlCommand::Connect {
+            ssid,
+            scan_args,
+            force,
+        } => wl::connect(),
+        WlCommand::Disconnect { forget } => wl::disconnect(),
+    }?;
+
     Ok(())
 }
 
@@ -21,6 +38,7 @@ struct Args {
 #[derive(Debug, Subcommand)]
 enum WlCommand {
     /// Show the overall status of WiFi (on/off, connected network if any)
+    #[clap(visible_alias = "s")]
     Status,
 
     /// Toggle WiFi on and off.

--- a/src/nmcli.rs
+++ b/src/nmcli.rs
@@ -1,0 +1,38 @@
+use std::{
+    io::{BufRead, Error},
+    process::Command,
+};
+
+pub fn get_active_connections() -> Result<Vec<String>, Error> {
+    let mut nmcli = Command::new("nmcli");
+    let cmd = nmcli
+        .args(["-g", "NAME,DEVICE"])
+        .arg("connection")
+        .arg("show")
+        .arg("--active")
+        .output()?;
+
+    if !cmd.status.success() {
+        let nmcli_err = cmd.stderr.lines().collect::<Result<String, Error>>()?;
+        return Err(Error::other(nmcli_err));
+    }
+
+    let active_conn_device_pairs = cmd.stdout.lines().collect::<Result<Vec<String>, Error>>()?;
+
+    Ok(active_conn_device_pairs)
+}
+
+pub fn get_wifi_status() -> Result<String, Error> {
+    let mut nmcli = Command::new("nmcli");
+    let cmd = nmcli.args(["-g", "WIFI"]).arg("g").output()?;
+
+    if !cmd.status.success() {
+        let nmcli_err = cmd.stderr.lines().collect::<Result<String, Error>>()?;
+        return Err(Error::other(nmcli_err));
+    }
+
+    cmd.stdout
+        .lines()
+        .take(1)
+        .collect::<Result<String, Error>>()
+}


### PR DESCRIPTION
Since `wl` uses `nmcli`, a new module is created for individual `nmcli` commands.

`wl status` (or `wl s` with alias) is implemented by printing the wifi status and connected networks to stdout.

Loopback interface is not stripped from connected networks since it represents a successful TCP configuration on the host.