### PR TITLE
feat(toggle): Implement `wl toggle`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::{error, fmt, io};
 pub enum Error {
     CannotGetActiveConnections(io::Error),
     CannotGetWifiStatus(io::Error),
+    CannotToggleWifi(io::Error),
 }
 
 impl error::Error for Error {}
@@ -16,7 +17,13 @@ impl fmt::Display for Error {
 }
 
 pub fn toggle() -> Result<(), Error> {
-    todo!()
+    let current_wifi_status = nmcli::get_wifi_status().map_err(Error::CannotGetWifiStatus)?;
+    let toggled_status =
+        nmcli::toggle_wifi(current_wifi_status).map_err(Error::CannotToggleWifi)?;
+
+    println!("wifi: {}", toggled_status);
+
+    Ok(())
 }
 
 pub fn status() -> Result<(), Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ enum WlCommand {
     Status,
 
     /// Toggle WiFi on and off.
+    #[clap(visible_alias = "t")]
     Toggle,
 
     /// See available WiFi networks.

--- a/src/nmcli.rs
+++ b/src/nmcli.rs
@@ -58,3 +58,28 @@ pub fn get_wifi_status() -> Result<WiFiStatus, Error> {
         WiFiStatus::Disabled
     })
 }
+
+pub fn toggle_wifi(old_status: WiFiStatus) -> Result<WiFiStatus, Error> {
+    let mut nmcli = Command::new("nmcli");
+    let cmd = nmcli.arg("radio").arg("wifi");
+
+    let new_status = match old_status {
+        WiFiStatus::Enabled => {
+            cmd.arg("off");
+            WiFiStatus::Disabled
+        }
+        WiFiStatus::Disabled => {
+            cmd.arg("on");
+            WiFiStatus::Enabled
+        }
+    };
+
+    let cmd = cmd.output()?;
+
+    if !cmd.status.success() {
+        let nmcli_err = cmd.stderr.lines().collect::<Result<String, Error>>()?;
+        return Err(Error::other(nmcli_err));
+    }
+
+    Ok(new_status)
+}


### PR DESCRIPTION
`wl toggle` (or `wl t` with alias) is implemented by getting the current wifi status, and calling `nmcli::toggle_wifi` to change it.

Upon a successful execution, the latest status is printed to stdout. Upon a failed execution, the `io::Error` is delegated to the caller.

The error messages and appropriate exit codes will be done in a separate commit.