### PR TITLE
feat(list-networks): Implement `wl list-networks`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub enum Error {
     CannotGetActiveConnections(io::Error),
     CannotGetWifiStatus(io::Error),
     CannotToggleWifi(io::Error),
+    CannotListNetworks(io::Error),
 }
 
 impl error::Error for Error {}
@@ -27,7 +28,7 @@ pub fn toggle() -> Result<(), Error> {
 }
 
 pub fn status() -> Result<(), Error> {
-    let active_conns = nmcli::get_active_connections()
+    let active_conns = nmcli::show_active_connections()
         .map_err(Error::CannotGetActiveConnections)?
         .join(", ");
 
@@ -35,6 +36,16 @@ pub fn status() -> Result<(), Error> {
 
     println!("wifi: {}", wifi_status);
     println!("connected networks: {}", active_conns);
+
+    Ok(())
+}
+
+pub fn list_networks(active: bool, ssid: bool) -> Result<(), Error> {
+    let networks = nmcli::show_connections(active, ssid)
+        .map_err(Error::CannotListNetworks)?
+        .join("\n");
+
+    println!("{}", networks);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ fn run() -> Result<(), Box<dyn error::Error>> {
             force,
         } => wl::connect(),
         WlCommand::Disconnect { forget } => wl::disconnect(),
+        WlCommand::ListNetworks { active, ssid } => wl::list_networks(active, ssid),
     }?;
 
     Ok(())
@@ -66,6 +67,18 @@ enum WlCommand {
         /// Forget the network (delete it from the known network list).
         #[arg(short = 'd', long, default_value_t = false)]
         forget: bool,
+    },
+
+    /// See known networks.
+    #[clap(visible_alias = "ls")]
+    ListNetworks {
+        /// See active (connected) networks.
+        #[arg(short, long, default_value_t = false)]
+        active: bool,
+
+        /// Output the SSID's only.
+        #[arg(long, default_value_t = false)]
+        ssid: bool,
     },
 }
 

--- a/src/nmcli.rs
+++ b/src/nmcli.rs
@@ -79,10 +79,25 @@ pub fn show_active_connections() -> Result<Vec<String>, Error> {
     Ok(active_conn_device_pairs)
 }
 
+pub fn show_connections(active: bool, ssid: bool) -> Result<Vec<String>, Error> {
+    let mut nmcli = Nmcli::new();
 
+    if ssid {
+        nmcli.with_global_args(vec!["--fields", "NAME"]);
     }
 
+    nmcli.with_subcommands(vec!["connection", "show"]);
+
+    if active {
+        nmcli.with_subcommand_args(vec!["--active"]);
+    }
+
+    nmcli
+        .exec()?
         .lines()
+        .collect::<Result<Vec<String>, Error>>()
+}
+
 pub fn get_wifi_status() -> Result<WiFiStatus, Error> {
     let mut nmcli = Nmcli::new();
     nmcli

--- a/src/nmcli.rs
+++ b/src/nmcli.rs
@@ -18,39 +18,80 @@ impl fmt::Display for WiFiStatus {
     }
 }
 
-pub fn get_active_connections() -> Result<Vec<String>, Error> {
-    let mut nmcli = Command::new("nmcli");
-    let cmd = nmcli
-        .args(["-g", "NAME,DEVICE"])
-        .arg("connection")
-        .arg("show")
-        .arg("--active")
-        .output()?;
+struct Nmcli<'a> {
+    global_args: Vec<&'a str>,
+    subcommands: Vec<&'a str>,
+    subcommand_args: Vec<&'a str>,
+}
 
-    if !cmd.status.success() {
-        let nmcli_err = cmd.stderr.lines().collect::<Result<String, Error>>()?;
-        return Err(Error::other(nmcli_err));
+impl<'a> Nmcli<'a> {
+    fn new() -> Self {
+        Self {
+            global_args: vec![],
+            subcommands: vec![],
+            subcommand_args: vec![],
+        }
     }
 
-    let active_conn_device_pairs = cmd.stdout.lines().collect::<Result<Vec<String>, Error>>()?;
+    fn with_global_args(&mut self, args: Vec<&'a str>) -> &mut Self {
+        self.global_args = args;
+        self
+    }
+
+    fn with_subcommands(&mut self, cmds: Vec<&'a str>) -> &mut Self {
+        self.subcommands = cmds;
+        self
+    }
+
+    fn with_subcommand_args(&mut self, args: Vec<&'a str>) -> &mut Self {
+        self.subcommand_args = args;
+        self
+    }
+
+    fn exec(self) -> Result<Vec<u8>, Error> {
+        let mut nmcli = Command::new("nmcli");
+        let cmd = nmcli
+            .args(self.global_args)
+            .args(self.subcommands)
+            .args(self.subcommand_args)
+            .output()?;
+
+        if !cmd.status.success() {
+            let nmcli_err = cmd.stderr.lines().collect::<Result<String, Error>>()?;
+            return Err(Error::other(nmcli_err));
+        }
+
+        Ok(cmd.stdout)
+    }
+}
+
+pub fn show_active_connections() -> Result<Vec<String>, Error> {
+    let mut nmcli = Nmcli::new();
+    nmcli
+        .with_global_args(vec!["-g", "NAME,DEVICE"])
+        .with_subcommands(vec!["connection", "show"])
+        .with_subcommand_args(vec!["--active"]);
+
+    let result = nmcli.exec()?;
+
+    let active_conn_device_pairs = result.lines().collect::<Result<Vec<String>, Error>>()?;
 
     Ok(active_conn_device_pairs)
 }
 
-pub fn get_wifi_status() -> Result<WiFiStatus, Error> {
-    let mut nmcli = Command::new("nmcli");
-    let cmd = nmcli.args(["-g", "WIFI"]).arg("g").output()?;
 
-    if !cmd.status.success() {
-        let nmcli_err = cmd.stderr.lines().collect::<Result<String, Error>>()?;
-        return Err(Error::other(nmcli_err));
     }
 
-    let status = cmd
-        .stdout
         .lines()
-        .take(1)
-        .collect::<Result<String, Error>>()?;
+pub fn get_wifi_status() -> Result<WiFiStatus, Error> {
+    let mut nmcli = Nmcli::new();
+    nmcli
+        .with_global_args(vec!["-g", "WIFI"])
+        .with_subcommands(vec!["g"]);
+
+    let result = nmcli.exec()?;
+
+    let status = result.lines().take(1).collect::<Result<String, Error>>()?;
 
     Ok(if status == "enabled" {
         WiFiStatus::Enabled
@@ -60,26 +101,21 @@ pub fn get_wifi_status() -> Result<WiFiStatus, Error> {
 }
 
 pub fn toggle_wifi(old_status: WiFiStatus) -> Result<WiFiStatus, Error> {
-    let mut nmcli = Command::new("nmcli");
-    let cmd = nmcli.arg("radio").arg("wifi");
+    let mut nmcli = Nmcli::new();
+    nmcli.with_subcommands(vec!["radio", "wifi"]);
 
     let new_status = match old_status {
         WiFiStatus::Enabled => {
-            cmd.arg("off");
+            nmcli.with_subcommand_args(vec!["off"]);
             WiFiStatus::Disabled
         }
         WiFiStatus::Disabled => {
-            cmd.arg("on");
+            nmcli.with_subcommand_args(vec!["on"]);
             WiFiStatus::Enabled
         }
     };
 
-    let cmd = cmd.output()?;
-
-    if !cmd.status.success() {
-        let nmcli_err = cmd.stderr.lines().collect::<Result<String, Error>>()?;
-        return Err(Error::other(nmcli_err));
-    }
+    let _ = nmcli.exec()?;
 
     Ok(new_status)
 }


### PR DESCRIPTION
The CLI API is updated to have a new subcommand - `wl list-networks` - with an alias `wl ls`. 
It is implemented to have a way to list known networks on the host.

It takes two options, `--active` to list active (connected) networks, and  `--ssid` to see the names of the known networks.