### PR TITLE
feat(disconnect) - Implement `wl disconnect`

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -6,4 +6,5 @@ pub trait Wl {
     fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<Vec<String>, io::Error>;
     fn get_active_ssid_dev_pairs(&self) -> Result<Vec<String>, io::Error>;
     fn get_active_ssids(&self) -> Result<Vec<String>, io::Error>;
+    fn disconnect(&self, ssid: &str, forget: bool) -> Result<(), io::Error>;
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,0 +1,9 @@
+use std::{fmt, io};
+
+pub trait Wl {
+    fn get_wifi_status(&self) -> Result<impl fmt::Display, io::Error>;
+    fn toggle_wifi(&self, prev_status: &str) -> Result<impl fmt::Display, io::Error>;
+    fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<Vec<String>, io::Error>;
+    fn get_active_ssid_dev_pairs(&self) -> Result<Vec<String>, io::Error>;
+    fn get_active_ssids(&self) -> Result<Vec<String>, io::Error>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,10 @@ fn run() -> Result<(), Box<dyn error::Error>> {
             force,
         } => wl::connect(),
         WlCommand::Disconnect { forget } => wl::disconnect(),
-        WlCommand::ListNetworks { active, ssid } => wl::list_networks(active, ssid),
+        WlCommand::ListNetworks {
+            show_active,
+            show_ssid,
+        } => wl::list_networks(show_active, show_ssid),
     }?;
 
     Ok(())
@@ -73,12 +76,12 @@ enum WlCommand {
     #[clap(visible_alias = "ls")]
     ListNetworks {
         /// See active (connected) networks.
-        #[arg(short, long, default_value_t = false)]
-        active: bool,
+        #[arg(short = 'a', long = "active", default_value_t = false)]
+        show_active: bool,
 
         /// Output the SSID's only.
-        #[arg(long, default_value_t = false)]
-        ssid: bool,
+        #[arg(short = 's', long = "ssid", default_value_t = false)]
+        show_ssid: bool,
     },
 }
 
@@ -92,7 +95,7 @@ struct ScanArgs {
     #[arg(short = 'r', long, default_value_t = false)]
     re_scan: bool,
 
-    /// Set the re-scan refresh timer
+    /// Set the re-scan refresh timer.
     #[arg(short = 't', long, default_value_t = 5)]
     refresh_in: u8,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn run() -> Result<(), Box<dyn error::Error>> {
             scan_args,
             force,
         } => wl::connect(),
-        WlCommand::Disconnect { forget } => wl::disconnect(),
+        WlCommand::Disconnect { ssid, forget } => wl::disconnect(ssid, forget),
         WlCommand::ListNetworks {
             show_active,
             show_ssid,
@@ -65,11 +65,15 @@ enum WlCommand {
         force: bool,
     },
 
-    /// Disconnect from the currently connected WiFi network.
+    /// Disconnect from a WiFi network.
+    #[clap(visible_alias = "d")]
     Disconnect {
         /// Forget the network (delete it from the known network list).
         #[arg(short = 'd', long, default_value_t = false)]
         forget: bool,
+
+        /// SSID of the target network.
+        ssid: Option<String>,
     },
 
     /// See known networks.

--- a/src/nmcli.rs
+++ b/src/nmcli.rs
@@ -1,8 +1,12 @@
 use std::{
     fmt,
-    io::{BufRead, Error},
+    io::{self, BufRead, Error, Write},
     process::Command,
 };
+
+use crate::adapter::Wl;
+
+pub const LOOPBACK_INTERFACE_NAME: &str = "lo";
 
 pub enum WiFiStatus {
     Enabled,
@@ -18,43 +22,16 @@ impl fmt::Display for WiFiStatus {
     }
 }
 
-struct Nmcli<'a> {
-    global_args: Vec<&'a str>,
-    subcommands: Vec<&'a str>,
-    subcommand_args: Vec<&'a str>,
-}
+pub struct Nmcli;
 
-impl<'a> Nmcli<'a> {
-    fn new() -> Self {
-        Self {
-            global_args: vec![],
-            subcommands: vec![],
-            subcommand_args: vec![],
-        }
+impl Nmcli {
+    pub fn new() -> Self {
+        Self
     }
 
-    fn with_global_args(&mut self, args: Vec<&'a str>) -> &mut Self {
-        self.global_args = args;
-        self
-    }
-
-    fn with_subcommands(&mut self, cmds: Vec<&'a str>) -> &mut Self {
-        self.subcommands = cmds;
-        self
-    }
-
-    fn with_subcommand_args(&mut self, args: Vec<&'a str>) -> &mut Self {
-        self.subcommand_args = args;
-        self
-    }
-
-    fn exec(self) -> Result<Vec<u8>, Error> {
+    fn exec(&self, args: &[&str]) -> Result<Vec<u8>, Error> {
         let mut nmcli = Command::new("nmcli");
-        let cmd = nmcli
-            .args(self.global_args)
-            .args(self.subcommands)
-            .args(self.subcommand_args)
-            .output()?;
+        let cmd = nmcli.args(args).output()?;
 
         if !cmd.status.success() {
             let nmcli_err = cmd.stderr.lines().collect::<Result<String, Error>>()?;
@@ -65,72 +42,78 @@ impl<'a> Nmcli<'a> {
     }
 }
 
-pub fn show_active_connections() -> Result<Vec<String>, Error> {
-    let mut nmcli = Nmcli::new();
-    nmcli
-        .with_global_args(vec!["-g", "NAME,DEVICE"])
-        .with_subcommands(vec!["connection", "show"])
-        .with_subcommand_args(vec!["--active"]);
+impl Wl for Nmcli {
+    fn get_wifi_status(&self) -> Result<impl fmt::Display, Error> {
+        let args: [&str; 3] = ["-g", "WIFI", "g"];
+        let result = self.exec(&args)?;
 
-    let result = nmcli.exec()?;
+        let status = result.lines().take(1).collect::<Result<String, Error>>()?;
 
-    let active_conn_device_pairs = result.lines().collect::<Result<Vec<String>, Error>>()?;
-
-    Ok(active_conn_device_pairs)
-}
-
-pub fn show_connections(active: bool, ssid: bool) -> Result<Vec<String>, Error> {
-    let mut nmcli = Nmcli::new();
-
-    if ssid {
-        nmcli.with_global_args(vec!["--fields", "NAME"]);
-    }
-
-    nmcli.with_subcommands(vec!["connection", "show"]);
-
-    if active {
-        nmcli.with_subcommand_args(vec!["--active"]);
-    }
-
-    nmcli
-        .exec()?
-        .lines()
-        .collect::<Result<Vec<String>, Error>>()
-}
-
-pub fn get_wifi_status() -> Result<WiFiStatus, Error> {
-    let mut nmcli = Nmcli::new();
-    nmcli
-        .with_global_args(vec!["-g", "WIFI"])
-        .with_subcommands(vec!["g"]);
-
-    let result = nmcli.exec()?;
-
-    let status = result.lines().take(1).collect::<Result<String, Error>>()?;
-
-    Ok(if status == "enabled" {
-        WiFiStatus::Enabled
-    } else {
-        WiFiStatus::Disabled
-    })
-}
-
-pub fn toggle_wifi(old_status: WiFiStatus) -> Result<WiFiStatus, Error> {
-    let mut nmcli = Nmcli::new();
-    nmcli.with_subcommands(vec!["radio", "wifi"]);
-
-    let new_status = match old_status {
-        WiFiStatus::Enabled => {
-            nmcli.with_subcommand_args(vec!["off"]);
-            WiFiStatus::Disabled
-        }
-        WiFiStatus::Disabled => {
-            nmcli.with_subcommand_args(vec!["on"]);
+        Ok(if status == "enabled" {
             WiFiStatus::Enabled
+        } else {
+            WiFiStatus::Disabled
+        })
+    }
+
+    fn toggle_wifi(&self, prev_status: &str) -> Result<impl fmt::Display, Error> {
+        let mut args: [&str; 3] = ["radio", "wifi", ""];
+
+        let new_status = if prev_status == "enabled" {
+            args[2] = "off";
+            WiFiStatus::Disabled
+        } else {
+            args[2] = "on";
+            WiFiStatus::Enabled
+        };
+
+        let _ = self.exec(&args)?;
+
+        Ok(new_status)
+    }
+
+    // TODO: Return iter of tuples, which allows the caller to decide how to use it.
+    fn get_active_ssid_dev_pairs(&self) -> Result<Vec<String>, Error> {
+        let args: [&str; 5] = ["-g", "NAME,DEVICE", "connection", "show", "--active"];
+
+        let result = self.exec(&args)?;
+
+        let active_ssid_dev_pairs = result.lines().collect::<Result<Vec<String>, Error>>()?;
+        Ok(active_ssid_dev_pairs)
+    }
+
+    fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<Vec<String>, Error> {
+        let mut args: [&str; 5] = ["", "", "connection", "show", ""];
+
+        if show_ssid {
+            args[0] = "--fields";
+            args[1] = "NAME";
         }
-    };
 
-    let _ = nmcli.exec()?;
+        if show_active {
+            args[4] = "--active";
+        }
 
-    Ok(new_status)
+        let args: Vec<&str> = args.into_iter().filter(|a| !a.is_empty()).collect();
+
+        self.exec(&args[..])?
+            .lines()
+            .collect::<Result<Vec<String>, Error>>()
+    }
+
+    fn get_active_ssids(&self) -> Result<Vec<String>, Error> {
+        let args: [&str; 5] = ["-g", "NAME", "connection", "show", "--active"];
+
+        let result = self.exec(&args)?;
+
+        result
+            .lines()
+            .filter(|l| match l {
+                Ok(l) => !l.contains(LOOPBACK_INTERFACE_NAME),
+                Err(_) => true,
+            })
+            .collect()
+    }
+
+
 }

--- a/src/nmcli.rs
+++ b/src/nmcli.rs
@@ -115,5 +115,11 @@ impl Wl for Nmcli {
             .collect()
     }
 
+    fn disconnect(&self, ssid: &str, forget: bool) -> Result<(), Error> {
+        let mut args: [&str; 4] = ["connection", "", "id", ssid];
+        args[1] = if forget { "delete" } else { "down" };
 
+        let result = self.exec(&args)?;
+        io::stdout().write_all(&result[..])
+    }
 }


### PR DESCRIPTION
`wl disconnect` (or `wl d` with alias) is designed to cover multiple network disconnections and removals.

Since entering SSID by hand is not a welcoming experience, `wl disconnect` is implemented with a small interactivity. If users do not provide an SSID, it shows the active connections to let users choose.

As decided before, `--forget` flag is implemented to remove the selected network from the known network list. Whilst keeping a network in known network list makes it a lot easier and faster to connect to it, a hard delete is required in some cases (e.g. when the password of the network changes).

### Other Changes

This PR also adds support for multiple network backends to `wl` by introducing a new module - `adapter` - to the project, which holds the `Wl` trait.
`Nmcli` is updated to satisfy the trait, and the overall struct design and functionalities are simplified.