### PR TITLE
refactor(nmcli): Move `wl ls` output to `wl::nmcli`

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -3,7 +3,7 @@ use std::{fmt, io};
 pub trait Wl {
     fn get_wifi_status(&self) -> Result<impl fmt::Display, io::Error>;
     fn toggle_wifi(&self, prev_status: &str) -> Result<impl fmt::Display, io::Error>;
-    fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<Vec<String>, io::Error>;
+    fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<(), io::Error>;
     fn get_active_ssid_dev_pairs(&self) -> Result<Vec<String>, io::Error>;
     fn get_active_ssids(&self) -> Result<Vec<String>, io::Error>;
     fn disconnect(&self, ssid: &str, forget: bool) -> Result<(), io::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,14 +67,9 @@ pub fn status() -> Result<(), Error> {
 
 pub fn list_networks(show_active: bool, show_ssid: bool) -> Result<(), Error> {
     let process = crate::new();
-    let networks = process
+    process
         .list_networks(show_active, show_ssid)
-        .map_err(Error::CannotListNetworks)?
-        .join("\n");
-
-    println!("{}", networks);
-
-    Ok(())
+        .map_err(Error::CannotListNetworks)
 }
 
 pub fn connect() -> Result<(), Error> {

--- a/src/nmcli.rs
+++ b/src/nmcli.rs
@@ -82,7 +82,7 @@ impl Wl for Nmcli {
         Ok(active_ssid_dev_pairs)
     }
 
-    fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<Vec<String>, Error> {
+    fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<(), Error> {
         let mut args: [&str; 5] = ["", "", "connection", "show", ""];
 
         if show_ssid {
@@ -96,9 +96,8 @@ impl Wl for Nmcli {
 
         let args: Vec<&str> = args.into_iter().filter(|a| !a.is_empty()).collect();
 
-        self.exec(&args[..])?
-            .lines()
-            .collect::<Result<Vec<String>, Error>>()
+        let result = self.exec(&args[..])?;
+        io::stdout().write_all(&result)
     }
 
     fn get_active_ssids(&self) -> Result<Vec<String>, Error> {


### PR DESCRIPTION
The callers of `nmcli` module should not know the format of the returned `String`'s.

In `wl::list_networks()`, the process result `Vec<String>` is joined with newlines. This essentially means that the caller of `process.list_networks()` know that the vector actually represents lines of networks.

However, this can't be figured out from the signature of `process.list_networks()` alone (`Vec<String>`).

Therefore, the responsibility of printing the networks is moved back to `nmcli` module. 
Lib crate should stay lean, and if the output of a network backend module is directly printed to the user, its format should be decided by the module itself, not by the caller.