### PR TITLE
refactor(encoding): Support non UTF8 inputs

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -5,6 +5,6 @@ pub trait Wl {
     fn toggle_wifi(&self, prev_status: &str) -> Result<impl fmt::Display, io::Error>;
     fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<(), io::Error>;
     fn get_active_ssid_dev_pairs(&self) -> Result<Vec<String>, io::Error>;
-    fn get_active_ssids(&self) -> Result<Vec<String>, io::Error>;
-    fn disconnect(&self, ssid: &str, forget: bool) -> Result<(), io::Error>;
+    fn get_active_ssids(&self) -> Result<Vec<Vec<u8>>, io::Error>;
+    fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<(), io::Error>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use std::{error, process::ExitCode};
+use std::{error, ffi::OsString, os::unix::ffi::OsStringExt, process::ExitCode};
 
 // TODO: add err handling and proper exit codes.
 fn main() -> ExitCode {
@@ -22,7 +22,10 @@ fn run() -> Result<(), Box<dyn error::Error>> {
             scan_args,
             force,
         } => wl::connect(),
-        WlCommand::Disconnect { ssid, forget } => wl::disconnect(ssid, forget),
+        WlCommand::Disconnect { ssid, forget } => {
+            let ssid = ssid.map(OsStringExt::into_vec);
+            wl::disconnect(ssid, forget)
+        }
         WlCommand::ListNetworks {
             show_active,
             show_ssid,
@@ -55,7 +58,7 @@ enum WlCommand {
     /// Connect to a WiFi network.
     Connect {
         //// SSID to connect.
-        ssid: Option<String>,
+        ssid: Option<OsString>,
 
         #[command(flatten)]
         scan_args: ScanArgs,
@@ -73,7 +76,7 @@ enum WlCommand {
         forget: bool,
 
         /// SSID of the target network.
-        ssid: Option<String>,
+        ssid: Option<OsString>,
     },
 
     /// See known networks.


### PR DESCRIPTION
Up to this point, both the `wl` args and the output of the underlying network backend (`nmcli`) were assumed to be encoded in UTF-8.

However, this is not necessarily true all the time simply because SSID's may contain non UTF-8 values. This effects the whole project since SSID's are used pretty much in every `wl` subcommand.

Right now, if a non UTF-8 SSID is retrieved from `nmcli`, the corresponding `wl` subcommand fails because `wl` expects valid UTF-8 output from `nmcli`.

Therefore, the whole project is updated to support both UTF-8 and non UTF-8 values by processing `u8` instead of `String`'s.

However, this change does not support Windows platforms, but that is an acceptable tradeoff since `wl` is designed to work on Unix hosts only.