### PR TITLE
refactor(nmcli): Use tuple to for ssid/dev pairs

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,10 +1,12 @@
 use std::{fmt, io};
 
+pub type SsidDevPair = (Vec<u8>, Vec<u8>);
+
 pub trait Wl {
     fn get_wifi_status(&self) -> Result<impl fmt::Display, io::Error>;
     fn toggle_wifi(&self, prev_status: &str) -> Result<impl fmt::Display, io::Error>;
     fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<(), io::Error>;
-    fn get_active_ssid_dev_pairs(&self) -> Result<Vec<String>, io::Error>;
+    fn get_active_ssid_dev_pairs(&self) -> Result<Vec<SsidDevPair>, io::Error>;
     fn get_active_ssids(&self) -> Result<Vec<Vec<u8>>, io::Error>;
     fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<(), io::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,17 +51,23 @@ pub fn toggle() -> Result<(), Error> {
 
 pub fn status() -> Result<(), Error> {
     let process = crate::new();
-    let active_conns = process
+    let pairs = process
         .get_active_ssid_dev_pairs()
-        .map_err(Error::CannotGetActiveConnections)?
-        .join(", ");
+        .map_err(Error::CannotGetActiveConnections)?;
 
     let wifi_status = process
         .get_wifi_status()
         .map_err(Error::CannotGetWifiStatus)?;
 
-    println!("wifi: {}", wifi_status);
-    println!("connected networks: {}", active_conns);
+    let out_buf = format!("wifi: {}\n", wifi_status);
+    write_out(out_buf.as_bytes())?;
+
+    let mut out_buf: Vec<u8> = b"connected networks: ".to_vec();
+    for (ssid, dev) in pairs {
+        let mut pair = [&ssid[..], b"/", &dev[..], b", "].concat();
+        out_buf.append(&mut pair);
+    }
+    write_out(out_buf.strip_suffix(b", ").unwrap())?;
 
     Ok(())
 }


### PR DESCRIPTION
The first version of `nmcli` returned `Vec<Vec<String>>` for ssid-dev pairs, which is joined by lib crate (caller) via ", ".

While this resulted in a correct ssid-dev pair format, using ", " indicated that the caller knows the actual format of `Vec<Vec<String>>` which cannot be decided from the `Wl::get_active_ssid_dev_pairs` signature only.

To resolve this ambiguity and mix of responsibilities about the return type and its contents, a new type is introduced in `adapter` - `SsidDevPair` - which is a tuple with 2 elements.