### PR TITLE
refactor(toggle): Fetch prev WiFi status in net be

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -4,7 +4,7 @@ pub type SsidDevPair = (Vec<u8>, Vec<u8>);
 
 pub trait Wl {
     fn get_wifi_status(&self) -> Result<impl fmt::Display, io::Error>;
-    fn toggle_wifi(&self, prev_status: &str) -> Result<impl fmt::Display, io::Error>;
+    fn toggle_wifi(&self) -> Result<impl fmt::Display, io::Error>;
     fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<(), io::Error>;
     fn get_active_ssid_dev_pairs(&self) -> Result<Vec<SsidDevPair>, io::Error>;
     fn get_active_ssids(&self) -> Result<Vec<Vec<u8>>, io::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,17 +34,10 @@ pub fn new() -> impl adapter::Wl {
 
 pub fn toggle() -> Result<(), Error> {
     let process = crate::new();
-    let prev_status = process
-        .get_wifi_status()
-        .map_err(Error::CannotGetWifiStatus)?
-        .to_string();
+    let toggled_status = process.toggle_wifi().map_err(Error::CannotToggleWifi)?;
 
-    let process = crate::new();
-    let toggled_status = process
-        .toggle_wifi(prev_status.as_str())
-        .map_err(Error::CannotToggleWifi)?;
-
-    println!("wifi: {}", toggled_status);
+    let out_buf = format!("wifi: {}\n", toggled_status);
+    write_out(out_buf.as_bytes())?;
 
     Ok(())
 }


### PR DESCRIPTION
Instead of requiring the previous WiFi status from the caller, `Wl::toggle_wifi` is updated to fetch the status by itself.

It does this by cloning the network backend struct to create another backend process, which is quite cheap since the struct itself does not allocate any memory.