### PR TITLE
refactor(wl): Create submodules for lib and bin

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,79 @@
+use std::ffi::OsString;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    #[command(subcommand)]
+    pub wl_command: Option<WlCommand>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WlCommand {
+    /// Show the overall status of WiFi (on/off, connected network if any)
+    #[clap(visible_alias = "s")]
+    Status,
+
+    /// Toggle WiFi on and off.
+    #[clap(visible_alias = "t")]
+    Toggle,
+
+    /// See available WiFi networks.
+    Scan(ScanArgs),
+
+    /// Connect to a WiFi network.
+    Connect {
+        //// SSID to connect.
+        ssid: Option<OsString>,
+
+        #[command(flatten)]
+        scan_args: ScanArgs,
+
+        /// Re-enter the SSID password even if it is a known network.
+        #[arg(short, long, default_value_t = false)]
+        force: bool,
+    },
+
+    /// Disconnect from a WiFi network.
+    #[clap(visible_alias = "d")]
+    Disconnect {
+        /// Forget the network (delete it from the known network list).
+        #[arg(short = 'd', long, default_value_t = false)]
+        forget: bool,
+
+        /// SSID of the target network.
+        ssid: Option<OsString>,
+    },
+
+    /// See known networks.
+    #[clap(visible_alias = "ls")]
+    ListNetworks {
+        /// See active (connected) networks.
+        #[arg(short = 'a', long = "active", default_value_t = false)]
+        show_active: bool,
+
+        /// Output the SSID's only.
+        #[arg(short = 's', long = "ssid", default_value_t = false)]
+        show_ssid: bool,
+    },
+}
+
+#[derive(clap::Args, Debug)]
+pub struct ScanArgs {
+    /// Filter scan list based on minimum WiFi signal strength (1 to 100).
+    #[arg(short = 's', long, default_value_t = 40)]
+    min_strength: u8,
+
+    /// Bypass cache and force a re-scan.
+    #[arg(short = 'r', long, default_value_t = false)]
+    re_scan: bool,
+
+    /// Show specified fields only.
+    #[arg(short = 'f', long)]
+    fields: Option<String>,
+
+    /// Show values of specified fields (terse output).
+    #[arg(short = 'g', long)]
+    get_values: Option<String>,
+}

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,0 +1,5 @@
+use crate::Error;
+
+pub fn connect() -> Result<(), Error> {
+    todo!()
+}

--- a/src/disconnect.rs
+++ b/src/disconnect.rs
@@ -1,0 +1,61 @@
+use std::{
+    collections::HashMap,
+    io::{self, Write},
+};
+
+use crate::{Error, adapter::Wl, write_out};
+
+pub fn disconnect(ssid: Option<Vec<u8>>, forget: bool) -> Result<(), Error> {
+    let ssid = match ssid {
+        Some(val) => val,
+        None => select_active_ssid()?,
+    };
+
+    let process = crate::new();
+    process
+        .disconnect(&ssid, forget)
+        .map_err(Error::CouldNotDisconnect)
+}
+
+fn select_active_ssid() -> Result<Vec<u8>, Error> {
+    let process = crate::new();
+    let active_ssids = process
+        .get_active_ssids()
+        .map_err(Error::CannotGetActiveConnections)?;
+
+    let mut ssids = Vec::new();
+    let mut conns = HashMap::new();
+
+    for (idx, ssid) in active_ssids.into_iter().enumerate() {
+        ssids = [
+            &ssids[..],
+            b"(",
+            idx.to_string().as_bytes(),
+            b") ",
+            &ssid[..],
+        ]
+        .concat();
+        conns.insert(idx, ssid);
+    }
+
+    let out_buf = &[
+        b"Select the SSID you want to disconnect from:\n",
+        &ssids[..],
+        b"\n> ",
+    ]
+    .concat();
+    write_out(out_buf)?;
+    io::stdout().flush().map_err(Error::CouldNotAskSSID)?;
+
+    let mut answer_buf = String::new();
+    io::stdin()
+        .read_line(&mut answer_buf)
+        .map_err(|err| Error::InvalidActiveSSID(Some(err.to_string())))?;
+
+    let answer = answer_buf
+        .trim()
+        .parse::<usize>()
+        .map_err(|err| Error::InvalidActiveSSID(Some(err.to_string())))?;
+
+    conns.remove(&answer).ok_or(Error::InvalidActiveSSID(None))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,24 @@
 mod adapter;
+pub mod api;
+mod connect;
+mod disconnect;
+mod list_networks;
 mod nmcli;
+mod scan;
+mod status;
+mod toggle;
 
 use std::{
-    collections::HashMap,
     error, fmt,
     io::{self, Write},
 };
 
-use adapter::Wl;
+pub use connect::connect;
+pub use disconnect::disconnect;
+pub use list_networks::list_networks;
+pub use scan::scan;
+pub use status::status;
+pub use toggle::toggle;
 
 #[derive(Debug)]
 pub enum Error {
@@ -30,109 +41,6 @@ impl fmt::Display for Error {
 
 pub fn new() -> impl adapter::Wl {
     nmcli::Nmcli::new()
-}
-
-pub fn toggle() -> Result<(), Error> {
-    let process = crate::new();
-    let toggled_status = process.toggle_wifi().map_err(Error::CannotToggleWifi)?;
-
-    let out_buf = format!("wifi: {}\n", toggled_status);
-    write_out(out_buf.as_bytes())?;
-
-    Ok(())
-}
-
-pub fn status() -> Result<(), Error> {
-    let process = crate::new();
-    let pairs = process
-        .get_active_ssid_dev_pairs()
-        .map_err(Error::CannotGetActiveConnections)?;
-
-    let wifi_status = process
-        .get_wifi_status()
-        .map_err(Error::CannotGetWifiStatus)?;
-
-    let out_buf = format!("wifi: {}\n", wifi_status);
-    write_out(out_buf.as_bytes())?;
-
-    let mut out_buf: Vec<u8> = b"connected networks: ".to_vec();
-    for (ssid, dev) in pairs {
-        let mut pair = [&ssid[..], b"/", &dev[..], b", "].concat();
-        out_buf.append(&mut pair);
-    }
-    write_out(out_buf.strip_suffix(b", ").unwrap())?;
-
-    Ok(())
-}
-
-pub fn list_networks(show_active: bool, show_ssid: bool) -> Result<(), Error> {
-    let process = crate::new();
-    process
-        .list_networks(show_active, show_ssid)
-        .map_err(Error::CannotListNetworks)
-}
-
-pub fn connect() -> Result<(), Error> {
-    todo!()
-}
-
-pub fn scan() -> Result<(), Error> {
-    todo!()
-}
-
-pub fn disconnect(ssid: Option<Vec<u8>>, forget: bool) -> Result<(), Error> {
-    let ssid = match ssid {
-        Some(val) => val,
-        None => select_active_ssid()?,
-    };
-
-    let process = crate::new();
-    process
-        .disconnect(&ssid, forget)
-        .map_err(Error::CouldNotDisconnect)
-}
-
-fn select_active_ssid() -> Result<Vec<u8>, Error> {
-    let process = crate::new();
-    let active_ssids = process
-        .get_active_ssids()
-        .map_err(Error::CannotGetActiveConnections)?;
-
-    let mut ssids = Vec::new();
-    let mut conns = HashMap::new();
-
-    for (idx, ssid) in active_ssids.into_iter().enumerate() {
-        ssids = [
-            &ssids[..],
-            b"(",
-            idx.to_string().as_bytes(),
-            b") ",
-            &ssid[..],
-        ]
-        .concat();
-        conns.insert(idx, ssid);
-    }
-
-    let out_buf = &[
-        b"Select the SSID you want to disconnect from:\n",
-        &ssids[..],
-        b"\n> ",
-    ]
-    .concat();
-    write_out(out_buf)?;
-    io::stdout().flush().map_err(Error::CouldNotAskSSID)?;
-
-    let mut answer_buf = String::new();
-    io::stdin()
-        .read_line(&mut answer_buf)
-        .map_err(|err| Error::InvalidActiveSSID(Some(err.to_string())))?;
-
-    let answer = answer_buf
-        .trim()
-        .parse::<usize>()
-        .map_err(|err| Error::InvalidActiveSSID(Some(err.to_string())))?;
-
-    conns.remove(&answer).ok_or(Error::InvalidActiveSSID(None))
 }
 
 fn write_out(buf: &[u8]) -> Result<(), Error> {

--- a/src/list_networks.rs
+++ b/src/list_networks.rs
@@ -1,0 +1,8 @@
+use crate::{Error, adapter::Wl};
+
+pub fn list_networks(show_active: bool, show_ssid: bool) -> Result<(), Error> {
+    let process = crate::new();
+    process
+        .list_networks(show_active, show_ssid)
+        .map_err(Error::CannotListNetworks)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
-use clap::{Parser, Subcommand};
-use std::{error, ffi::OsString, os::unix::ffi::OsStringExt, process::ExitCode};
+use std::{error, os::unix::ffi::OsStringExt, process::ExitCode};
+
+use clap::Parser;
+use wl::api;
 
 // TODO: add err handling and proper exit codes.
 fn main() -> ExitCode {
@@ -10,103 +12,27 @@ fn main() -> ExitCode {
 }
 
 fn run() -> Result<(), Box<dyn error::Error>> {
-    let args = Args::parse();
+    let args = api::Args::parse();
 
-    let wl_cmd = args.wl_command.unwrap_or(WlCommand::Status);
+    let wl_cmd = args.wl_command.unwrap_or(api::WlCommand::Status);
     match wl_cmd {
-        WlCommand::Status => wl::status(),
-        WlCommand::Toggle => wl::toggle(),
-        WlCommand::Scan(scan_args) => wl::scan(),
-        WlCommand::Connect {
+        api::WlCommand::Status => wl::status(),
+        api::WlCommand::Toggle => wl::toggle(),
+        api::WlCommand::Scan(scan_args) => wl::scan(scan_args),
+        api::WlCommand::Connect {
             ssid,
             scan_args,
             force,
         } => wl::connect(),
-        WlCommand::Disconnect { ssid, forget } => {
+        api::WlCommand::Disconnect { ssid, forget } => {
             let ssid = ssid.map(OsStringExt::into_vec);
             wl::disconnect(ssid, forget)
         }
-        WlCommand::ListNetworks {
+        api::WlCommand::ListNetworks {
             show_active,
             show_ssid,
         } => wl::list_networks(show_active, show_ssid),
     }?;
 
     Ok(())
-}
-
-#[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
-struct Args {
-    #[command(subcommand)]
-    wl_command: Option<WlCommand>,
-}
-
-#[derive(Debug, Subcommand)]
-enum WlCommand {
-    /// Show the overall status of WiFi (on/off, connected network if any)
-    #[clap(visible_alias = "s")]
-    Status,
-
-    /// Toggle WiFi on and off.
-    #[clap(visible_alias = "t")]
-    Toggle,
-
-    /// See available WiFi networks.
-    Scan(ScanArgs),
-
-    /// Connect to a WiFi network.
-    Connect {
-        //// SSID to connect.
-        ssid: Option<OsString>,
-
-        #[command(flatten)]
-        scan_args: ScanArgs,
-
-        /// Re-enter the SSID password even if it is a known network.
-        #[arg(short, long, default_value_t = false)]
-        force: bool,
-    },
-
-    /// Disconnect from a WiFi network.
-    #[clap(visible_alias = "d")]
-    Disconnect {
-        /// Forget the network (delete it from the known network list).
-        #[arg(short = 'd', long, default_value_t = false)]
-        forget: bool,
-
-        /// SSID of the target network.
-        ssid: Option<OsString>,
-    },
-
-    /// See known networks.
-    #[clap(visible_alias = "ls")]
-    ListNetworks {
-        /// See active (connected) networks.
-        #[arg(short = 'a', long = "active", default_value_t = false)]
-        show_active: bool,
-
-        /// Output the SSID's only.
-        #[arg(short = 's', long = "ssid", default_value_t = false)]
-        show_ssid: bool,
-    },
-}
-
-#[derive(clap::Args, Debug)]
-struct ScanArgs {
-    /// Filter scan list based on minimum WiFi signal strength (1 to 100).
-    #[arg(short = 's', long, default_value_t = 40)]
-    min_strength: u8,
-
-    /// Bypass cache and force a re-scan.
-    #[arg(short = 'r', long, default_value_t = false)]
-    re_scan: bool,
-
-    /// Show specified fields only.
-    #[arg(short = 'f', long)]
-    fields: Option<String>,
-
-    /// Show values of specified fields (terse output).
-    #[arg(short = 'g', long)]
-    get_values: Option<String>,
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,0 +1,6 @@
+use crate::Error;
+use crate::api::ScanArgs;
+
+pub fn scan(args: ScanArgs) -> Result<(), Error> {
+    todo!()
+}

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,24 @@
+use crate::{Error, adapter::Wl, write_out};
+
+pub fn status() -> Result<(), Error> {
+    let process = crate::new();
+    let pairs = process
+        .get_active_ssid_dev_pairs()
+        .map_err(Error::CannotGetActiveConnections)?;
+
+    let wifi_status = process
+        .get_wifi_status()
+        .map_err(Error::CannotGetWifiStatus)?;
+
+    let out_buf = format!("wifi: {}\n", wifi_status);
+    write_out(out_buf.as_bytes())?;
+
+    let mut out_buf: Vec<u8> = b"connected networks: ".to_vec();
+    for (ssid, dev) in pairs {
+        let mut pair = [&ssid[..], b"/", &dev[..], b", "].concat();
+        out_buf.append(&mut pair);
+    }
+    write_out(out_buf.strip_suffix(b", ").unwrap())?;
+
+    Ok(())
+}

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -1,0 +1,11 @@
+use crate::{Error, adapter::Wl, write_out};
+
+pub fn toggle() -> Result<(), Error> {
+    let process = crate::new();
+    let toggled_status = process.toggle_wifi().map_err(Error::CannotToggleWifi)?;
+
+    let out_buf = format!("wifi: {}\n", toggled_status);
+    write_out(out_buf.as_bytes())?;
+
+    Ok(())
+}


### PR DESCRIPTION
Since `wl scan` takes a complex type as an argument, it was not possible to bring that type into lib crate's scope since the type was defined in the binary crate.

Therefore, a new module `api` is defined under the library crate to contain the `clap` structs and reference them freely in `wl` subcommands if needed.

While we are at it, the library crate is divided into submodules based on each subcommand as well.