### PR TITLE
feat(scan): Implement `wl scan`

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,5 +1,7 @@
 use std::{fmt, io};
 
+use crate::api::ScanArgs;
+
 pub type SsidDevPair = (Vec<u8>, Vec<u8>);
 
 pub trait Wl {
@@ -9,6 +11,7 @@ pub trait Wl {
     fn get_active_ssid_dev_pairs(&self) -> Result<Vec<SsidDevPair>, io::Error>;
     fn get_active_ssids(&self) -> Result<Vec<Vec<u8>>, io::Error>;
     fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<(), io::Error>;
+    fn scan(&self, args: &ScanArgs) -> Result<Vec<u8>, io::Error>;
 }
 
 pub struct Decimal(u8);

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -10,3 +10,17 @@ pub trait Wl {
     fn get_active_ssids(&self) -> Result<Vec<Vec<u8>>, io::Error>;
     fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<(), io::Error>;
 }
+
+pub struct Decimal(u8);
+
+impl From<&[u8]> for Decimal {
+    fn from(value: &[u8]) -> Self {
+        Self(value.iter().fold(0, |acc, b| acc * 10 + (b - b'0')))
+    }
+}
+
+impl Decimal {
+    pub fn inner(&self) -> u8 {
+        self.0
+    }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -20,11 +20,16 @@ pub enum WlCommand {
     Toggle,
 
     /// See available WiFi networks.
-    Scan(ScanArgs),
+    #[clap(visible_alias = "sc")]
+    Scan {
+        #[command(flatten)]
+        args: ScanArgs,
+    },
 
     /// Connect to a WiFi network.
     Connect {
         //// SSID to connect.
+        #[arg(short = 'i', long)]
         ssid: Option<OsString>,
 
         #[command(flatten)]
@@ -61,19 +66,19 @@ pub enum WlCommand {
 
 #[derive(clap::Args, Debug)]
 pub struct ScanArgs {
-    /// Filter scan list based on minimum WiFi signal strength (1 to 100).
-    #[arg(short = 's', long, default_value_t = 40)]
-    min_strength: u8,
+    /// Filter scan list based on minimum WiFi signal strength (0 to 100).
+    #[arg(short = 's', long, default_value_t = 0)]
+    pub min_strength: u8,
 
     /// Bypass cache and force a re-scan.
     #[arg(short = 'r', long, default_value_t = false)]
-    re_scan: bool,
+    pub re_scan: bool,
 
-    /// Show specified fields only.
-    #[arg(short = 'f', long)]
-    fields: Option<String>,
+    /// Show specified columns only.
+    #[arg(short = 'c', long, conflicts_with = "get_values")]
+    pub columns: Option<String>,
 
     /// Show values of specified fields (terse output).
     #[arg(short = 'g', long)]
-    get_values: Option<String>,
+    pub get_values: Option<String>,
 }

--- a/src/disconnect.rs
+++ b/src/disconnect.rs
@@ -33,10 +33,13 @@ fn select_active_ssid() -> Result<Vec<u8>, Error> {
             idx.to_string().as_bytes(),
             b") ",
             &ssid[..],
+            b"\n",
         ]
         .concat();
         conns.insert(idx, ssid);
     }
+
+    let mut stdout = io::stdout();
 
     let out_buf = &[
         b"Select the SSID you want to disconnect from:\n",
@@ -44,8 +47,8 @@ fn select_active_ssid() -> Result<Vec<u8>, Error> {
         b"\n> ",
     ]
     .concat();
-    write_out(out_buf)?;
-    io::stdout().flush().map_err(Error::CouldNotAskSSID)?;
+    write_out(io::stdout(), out_buf)?;
+    stdout.flush().map_err(Error::CouldNotAskSSID)?;
 
     let mut answer_buf = String::new();
     io::stdin()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub enum Error {
     CouldNotAskSSID(io::Error),
     CouldNotDisconnect(io::Error),
     CannotWriteStdout(io::Error),
+    CannotScanWiFi(io::Error),
+    InvalidSignalStrength,
 }
 
 impl error::Error for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,6 @@ pub fn new() -> impl adapter::Wl {
     nmcli::Nmcli::new()
 }
 
-fn write_out(buf: &[u8]) -> Result<(), Error> {
-    io::stdout()
-        .write_all(buf)
-        .map_err(Error::CannotWriteStdout)
+fn write_out(mut f: impl io::Write, buf: &[u8]) -> Result<(), Error> {
+    f.write_all(buf).map_err(Error::CannotWriteStdout)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{error, os::unix::ffi::OsStringExt, process::ExitCode};
+use std::{error, io, os::unix::ffi::OsStringExt, process::ExitCode};
 
 use clap::Parser;
 use wl::api;
@@ -18,7 +18,10 @@ fn run() -> Result<(), Box<dyn error::Error>> {
     match wl_cmd {
         api::WlCommand::Status => wl::status(),
         api::WlCommand::Toggle => wl::toggle(),
-        api::WlCommand::Scan(scan_args) => wl::scan(scan_args),
+        api::WlCommand::Scan { args } => {
+            let mut out_buf = io::stdout();
+            wl::scan(&mut out_buf, args)
+        }
         api::WlCommand::Connect {
             ssid,
             scan_args,

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,6 +1,17 @@
-use crate::Error;
-use crate::api::ScanArgs;
+use std::io;
 
-pub fn scan(args: ScanArgs) -> Result<(), Error> {
-    todo!()
+use crate::adapter::Wl;
+use crate::api::ScanArgs;
+use crate::{Error, write_out};
+
+pub fn scan(mut f: impl io::Write, args: ScanArgs) -> Result<(), Error> {
+    const MAX_SIGNAL_STRENGTH: u8 = 100u8;
+
+    let 0u8..=MAX_SIGNAL_STRENGTH = &args.min_strength else {
+        return Err(Error::InvalidSignalStrength);
+    };
+
+    let process = crate::new();
+    let result = process.scan(&args).map_err(Error::CannotScanWiFi)?;
+    write_out(&mut f, &result[..])
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,3 +1,5 @@
+use std::io;
+
 use crate::{Error, adapter::Wl, write_out};
 
 pub fn status() -> Result<(), Error> {
@@ -10,15 +12,17 @@ pub fn status() -> Result<(), Error> {
         .get_wifi_status()
         .map_err(Error::CannotGetWifiStatus)?;
 
+    let mut stdout = io::stdout();
+
     let out_buf = format!("wifi: {}\n", wifi_status);
-    write_out(out_buf.as_bytes())?;
+    write_out(&mut stdout, out_buf.as_bytes())?;
 
     let mut out_buf: Vec<u8> = b"connected networks: ".to_vec();
     for (ssid, dev) in pairs {
         let mut pair = [&ssid[..], b"/", &dev[..], b", "].concat();
         out_buf.append(&mut pair);
     }
-    write_out(out_buf.strip_suffix(b", ").unwrap())?;
+    write_out(&mut stdout, out_buf.strip_suffix(b", ").unwrap())?;
 
     Ok(())
 }

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -1,3 +1,5 @@
+use std::io;
+
 use crate::{Error, adapter::Wl, write_out};
 
 pub fn toggle() -> Result<(), Error> {
@@ -5,7 +7,7 @@ pub fn toggle() -> Result<(), Error> {
     let toggled_status = process.toggle_wifi().map_err(Error::CannotToggleWifi)?;
 
     let out_buf = format!("wifi: {}\n", toggled_status);
-    write_out(out_buf.as_bytes())?;
+    write_out(&mut io::stdout(), out_buf.as_bytes())?;
 
     Ok(())
 }


### PR DESCRIPTION
The subcommand `wl scan` (or `wl sc` with alias) is designed to scan available WiFi networks on the host.

In addition to the functionality provided by `nmcli`, a filtering is implemented based on each network's signal strength.
Since `nmcli` does not provide filtering, it is done by taking advantage of the caching done on the list instead.

However, the filtering is unfortunately non-deterministic since the cache may expire during the process which may result in user query showing different results than the signal filter query.

To decrease the possibilities of this happening, it is advised to use signal filtering with the `--re-scan` flag to refresh the cache before the filtering operation.

Keep in mind that this issue is related with `nmcli` only.