### PR TITLE
feat(api): Remove `ScanArgs` from `wl connect`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -32,9 +32,6 @@ pub enum WlCommand {
         #[arg(short = 'i', long)]
         ssid: Option<OsString>,
 
-        #[command(flatten)]
-        scan_args: ScanArgs,
-
         /// Re-enter the SSID password even if it is a known network.
         #[arg(short, long, default_value_t = false)]
         force: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,11 +22,7 @@ fn run() -> Result<(), Box<dyn error::Error>> {
             let mut out_buf = io::stdout();
             wl::scan(&mut out_buf, args)
         }
-        api::WlCommand::Connect {
-            ssid,
-            scan_args,
-            force,
-        } => wl::connect(),
+        api::WlCommand::Connect { ssid, force } => wl::connect(),
         api::WlCommand::Disconnect { ssid, forget } => {
             let ssid = ssid.map(OsStringExt::into_vec);
             wl::disconnect(ssid, forget)


### PR DESCRIPTION
Having `ScanArgs` in `wl connect` allows users to filter and get values that may not contain the SSID. So, by nature, user supplied arguments cannot be trusted in `wl connect` flow to show the SSID's. This leads to querying the network backend a second time to ensure that the SSID's are retrieved and shown to the user.

The default network backend, `nmcli` gives back non-deterministic query results if it is queried for multiple scans.

Therefore, to have a more deterministic flow, `ScanArgs` is removed from `wl connect`.

`wl connect` will show its own scan list to the user to ensure that SSID's are always shown and retrieved (if the `-i` flag is not provided).