### PR TITLE
feat(connect): Implement `wl connect`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "clap"
 version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +117,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "numtoa"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +164,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +193,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termion"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3669a69de26799d6321a5aa713f55f7e2cd37bd47be044b50f2acafc42c122bb"
+dependencies = [
+ "libc",
+ "libredox",
+ "numtoa",
+ "redox_termios",
 ]
 
 [[package]]
@@ -241,4 +297,5 @@ name = "wl"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "termion",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
+termion = { version = "4.0.5" }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,6 +1,6 @@
-use std::{fmt, io};
+use std::{error, fmt, io};
 
-use crate::api::ScanArgs;
+use crate::{api::ScanArgs, nmcli};
 
 pub const LINE_FEED: u8 = 0xA;
 pub const CARRIAGE_RETURN: u8 = 0xD;
@@ -8,13 +8,32 @@ pub const CARRIAGE_RETURN: u8 = 0xD;
 pub type SsidDevPair = (Vec<u8>, Vec<u8>);
 
 pub trait Wl {
-    fn get_wifi_status(&self) -> Result<impl fmt::Display, io::Error>;
-    fn toggle_wifi(&self) -> Result<impl fmt::Display, io::Error>;
-    fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<(), io::Error>;
-    fn get_active_ssid_dev_pairs(&self) -> Result<Vec<SsidDevPair>, io::Error>;
-    fn get_active_ssids(&self) -> Result<Vec<Vec<u8>>, io::Error>;
-    fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<(), io::Error>;
-    fn scan(&self, args: &ScanArgs) -> Result<Vec<u8>, io::Error>;
+    fn get_wifi_status(&self) -> Result<Vec<u8>, Error>;
+    fn toggle_wifi(&self) -> Result<Vec<u8>, Error>;
+    fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<Vec<u8>, Error>;
+    fn get_active_ssid_dev_pairs(&self) -> Result<Vec<SsidDevPair>, Error>;
+    fn get_active_ssids(&self) -> Result<Vec<Vec<u8>>, Error>;
+    fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<Vec<u8>, Error>;
+    fn scan(&self, args: &ScanArgs) -> Result<Vec<u8>, Error>;
+}
+
+#[derive(Debug)]
+pub enum Error {
+    CannotGetWiFiStatus(io::Error),
+    CannotToggleWiFi(io::Error),
+    CannotListNetworks(io::Error),
+    CannotGetActiveConnections(io::Error),
+    CannotGetSSIDStatus(io::Error),
+    CannotDisconnect(io::Error),
+    CannotScanWiFi(io::Error),
+    CannotConnect(io::Error),
+}
+
+impl error::Error for Error {}
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "will be implemented")
+    }
 }
 
 pub struct Decimal(u8);

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -2,6 +2,9 @@ use std::{fmt, io};
 
 use crate::api::ScanArgs;
 
+pub const LINE_FEED: u8 = 0xA;
+pub const CARRIAGE_RETURN: u8 = 0xD;
+
 pub type SsidDevPair = (Vec<u8>, Vec<u8>);
 
 pub trait Wl {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -8,6 +8,7 @@ pub const CARRIAGE_RETURN: u8 = 0xD;
 pub type SsidDevPair = (Vec<u8>, Vec<u8>);
 
 pub trait Wl {
+    fn get_field_separator(&self) -> u8;
     fn get_wifi_status(&self) -> Result<Vec<u8>, Error>;
     fn toggle_wifi(&self) -> Result<Vec<u8>, Error>;
     fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<Vec<u8>, Error>;

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -16,6 +16,13 @@ pub trait Wl {
     fn get_active_ssids(&self) -> Result<Vec<Vec<u8>>, Error>;
     fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<Vec<u8>, Error>;
     fn scan(&self, args: &ScanArgs) -> Result<Vec<u8>, Error>;
+    fn is_known_ssid(&self, ssid: &[u8]) -> Result<bool, Error>;
+    fn connect(
+        &self,
+        ssid: &[u8],
+        passwd: Option<&[u8]>,
+        is_known_ssid: bool,
+    ) -> Result<Vec<u8>, Error>;
 }
 
 pub fn new() -> impl Wl {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -17,6 +17,10 @@ pub trait Wl {
     fn scan(&self, args: &ScanArgs) -> Result<Vec<u8>, Error>;
 }
 
+pub fn new() -> impl Wl {
+    nmcli::Nmcli::new()
+}
+
 #[derive(Debug)]
 pub enum Error {
     CannotGetWiFiStatus(io::Error),

--- a/src/api.rs
+++ b/src/api.rs
@@ -41,11 +41,11 @@ pub enum WlCommand {
     #[clap(visible_alias = "d")]
     Disconnect {
         /// Forget the network (delete it from the known network list).
-        #[arg(short = 'd', long, default_value_t = false)]
+        #[arg(short = 'f', long, default_value_t = false)]
         forget: bool,
 
         /// SSID of the target network.
-        ssid: Option<OsString>,
+        ssid: Option<String>,
     },
 
     /// See known networks.

--- a/src/api.rs
+++ b/src/api.rs
@@ -27,7 +27,10 @@ pub enum WlCommand {
     /// Connect to a WiFi network.
     #[clap(visible_alias = "c")]
     Connect {
-        //// SSID to connect.
+        /// SSID to connect.
+        ///
+        /// If the SSID is not provided, then the program will do
+        /// a scan and show the available networks to the user to choose from.
         #[arg(short = 'i', long)]
         ssid: Option<String>,
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,3 @@
-use std::ffi::OsString;
-
 use clap::{Parser, Subcommand};
 
 #[derive(Parser, Debug)]
@@ -27,14 +25,15 @@ pub enum WlCommand {
     },
 
     /// Connect to a WiFi network.
+    #[clap(visible_alias = "c")]
     Connect {
         //// SSID to connect.
         #[arg(short = 'i', long)]
-        ssid: Option<OsString>,
+        ssid: Option<String>,
 
         /// Re-enter the SSID password even if it is a known network.
         #[arg(short, long, default_value_t = false)]
-        force: bool,
+        force_passwd: bool,
     },
 
     /// Disconnect from a WiFi network.

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,5 +1,140 @@
-use crate::Error;
+use std::{
+    collections::HashMap,
+    error, fmt,
+    io::{self},
+};
 
-pub fn connect() -> Result<(), Error> {
-    todo!()
+use termion::input::TermRead;
+
+use crate::{
+    adapter::{self, LINE_FEED, Wl},
+    api::ScanArgs,
+    write_bytes,
+};
+
+#[derive(Debug)]
+pub enum Error {
+    CannotReadPasswd(io::Error),
+    CannotReadSSID(Option<String>),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // WARN: Implement the missing error messages.
+        match self {
+            Error::CannotReadPasswd(error) => todo!(),
+            Error::CannotReadSSID(error) => todo!(),
+        }
+    }
+}
+impl error::Error for Error {}
+
+pub fn connect(ssid: Option<Vec<u8>>, force_passwd: bool) -> Result<(), Box<dyn error::Error>> {
+    let process = adapter::new();
+
+    let ssid = match ssid {
+        Some(v) => Ok(v),
+        None => ask_ssid(&process),
+    }?;
+
+    let is_known_ssid = process.is_known_ssid(&ssid)?;
+
+    let password = match force_passwd {
+        true => get_ssid_password(&ssid),
+        false => {
+            if is_known_ssid {
+                Ok(None)
+            } else {
+                get_ssid_password(&ssid)
+            }
+        }
+    }?;
+
+    let result = process.connect(&ssid, password.as_deref(), is_known_ssid)?;
+
+    let mut out_buf = io::stdout();
+    write_bytes(&mut out_buf, &result)?;
+
+    Ok(())
+}
+
+fn ask_ssid(process: &impl Wl) -> Result<Vec<u8>, Box<dyn error::Error>> {
+    let scan_args = ScanArgs {
+        min_strength: 0,
+        re_scan: true,
+        columns: None,
+        get_values: Some(String::from("SSID,SIGNAL")),
+    };
+    let scan_result = process.scan(&scan_args)?;
+
+    let separator = process.get_field_separator();
+    let parsed_scan_result = scan_result
+        .split(|b| b == &LINE_FEED)
+        .enumerate()
+        .filter_map(|(idx, l)| {
+            if l.is_empty() {
+                None
+            } else {
+                let fields = l
+                    .split(|b| b == &separator)
+                    .filter(|b| !b.is_empty())
+                    .collect::<Vec<&[u8]>>();
+
+                Some((idx, fields[0], fields[1]))
+            }
+        });
+
+    let mut ssids = HashMap::new();
+    let mut ssid_lines = Vec::new();
+    for (idx, ssid, signal) in parsed_scan_result.into_iter() {
+        ssids.insert(idx, ssid);
+
+        let line = [
+            b"(",
+            idx.to_string().as_bytes(),
+            b") ",
+            ssid,
+            b" (sig: ",
+            signal,
+            b")\n",
+        ]
+        .concat();
+        ssid_lines.push(line);
+    }
+
+    let prompt = [
+        &ssid_lines.into_iter().flatten().collect::<Vec<u8>>()[..],
+        b"Select the SSID to connect: ",
+    ]
+    .concat();
+
+    write_bytes(&mut io::stdout(), &prompt)?;
+
+    let mut answer = String::new();
+    io::stdin()
+        .read_line(&mut answer)
+        .map_err(|err| Error::CannotReadSSID(Some(err.to_string())))?;
+
+    let answer = answer
+        .trim()
+        .parse::<usize>()
+        .map_err(|err| Error::CannotReadSSID(Some(err.to_string())))?;
+
+    let ssid = ssids.remove(&answer).ok_or(Error::CannotReadSSID(None))?;
+
+    Ok(ssid.to_vec())
+}
+
+fn get_ssid_password(ssid: &[u8]) -> Result<Option<Vec<u8>>, Box<dyn error::Error>> {
+    let mut stdin = io::stdin();
+    let mut writer = io::stdout();
+
+    let out_buf = [b"Enter the password for ", ssid, b": "].concat();
+    write_bytes(&mut writer, &out_buf)?;
+
+    let passwd = stdin
+        .read_passwd(&mut writer)
+        .map_err(Error::CannotReadPasswd)?;
+
+    Ok(passwd.map(|pw| String::from(pw.trim()).into_bytes()))
 }

--- a/src/disconnect.rs
+++ b/src/disconnect.rs
@@ -25,7 +25,7 @@ pub fn disconnect(ssid: Option<Vec<u8>>, forget: bool) -> Result<(), Box<dyn err
         None => select_active_ssid()?,
     };
 
-    let process = crate::new();
+    let process = adapter::new();
     let result = process.disconnect(&ssid, forget)?;
 
     let mut out_buf = io::stdout();
@@ -35,7 +35,7 @@ pub fn disconnect(ssid: Option<Vec<u8>>, forget: bool) -> Result<(), Box<dyn err
 }
 
 fn select_active_ssid() -> Result<Vec<u8>, Box<dyn error::Error>> {
-    let process = crate::new();
+    let process = adapter::new();
     let active_ssids = process.get_active_ssids()?;
 
     let mut ssids = Vec::new();

--- a/src/disconnect.rs
+++ b/src/disconnect.rs
@@ -1,27 +1,42 @@
-use std::{
-    collections::HashMap,
-    io::{self, Write},
+use std::{collections::HashMap, error, fmt, io};
+
+use crate::{
+    adapter::{self, Wl},
+    write_bytes,
 };
 
-use crate::{Error, adapter::Wl, write_out};
+#[derive(Debug)]
+pub enum Error {
+    InvalidActiveSSID(Option<String>),
+}
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // WARN: Implement the missing error messages.
+        match self {
+            Error::InvalidActiveSSID(_) => todo!(),
+        }
+    }
+}
+impl error::Error for Error {}
 
-pub fn disconnect(ssid: Option<Vec<u8>>, forget: bool) -> Result<(), Error> {
+pub fn disconnect(ssid: Option<Vec<u8>>, forget: bool) -> Result<(), Box<dyn error::Error>> {
     let ssid = match ssid {
         Some(val) => val,
         None => select_active_ssid()?,
     };
 
     let process = crate::new();
-    process
-        .disconnect(&ssid, forget)
-        .map_err(Error::CouldNotDisconnect)
+    let result = process.disconnect(&ssid, forget)?;
+
+    let mut out_buf = io::stdout();
+    write_bytes(&mut out_buf, &result)?;
+
+    Ok(())
 }
 
-fn select_active_ssid() -> Result<Vec<u8>, Error> {
+fn select_active_ssid() -> Result<Vec<u8>, Box<dyn error::Error>> {
     let process = crate::new();
-    let active_ssids = process
-        .get_active_ssids()
-        .map_err(Error::CannotGetActiveConnections)?;
+    let active_ssids = process.get_active_ssids()?;
 
     let mut ssids = Vec::new();
     let mut conns = HashMap::new();
@@ -47,8 +62,7 @@ fn select_active_ssid() -> Result<Vec<u8>, Error> {
         b"\n> ",
     ]
     .concat();
-    write_out(io::stdout(), out_buf)?;
-    stdout.flush().map_err(Error::CouldNotAskSSID)?;
+    write_bytes(&mut stdout, out_buf)?;
 
     let mut answer_buf = String::new();
     io::stdin()
@@ -60,5 +74,9 @@ fn select_active_ssid() -> Result<Vec<u8>, Error> {
         .parse::<usize>()
         .map_err(|err| Error::InvalidActiveSSID(Some(err.to_string())))?;
 
-    conns.remove(&answer).ok_or(Error::InvalidActiveSSID(None))
+    let ssid = conns
+        .remove(&answer)
+        .ok_or(Error::InvalidActiveSSID(None))?;
+
+    Ok(ssid)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,6 @@ impl fmt::Display for Error {
 }
 impl error::Error for Error {}
 
-pub fn new() -> impl adapter::Wl {
-    nmcli::Nmcli::new()
-}
-
 fn write_bytes(f: &mut impl io::Write, buf: &[u8]) -> Result<(), Error> {
     f.write_all(buf).map_err(Error::CannotWriteBuffer)?;
     f.flush().map_err(Error::CannotFlushWriter)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,31 +20,28 @@ pub use scan::scan;
 pub use status::status;
 pub use toggle::toggle;
 
+use std::{error, fmt, io};
+
 #[derive(Debug)]
 pub enum Error {
-    CannotGetActiveConnections(io::Error),
-    CannotGetWifiStatus(io::Error),
-    CannotToggleWifi(io::Error),
-    CannotListNetworks(io::Error),
-    InvalidActiveSSID(Option<String>),
-    CouldNotAskSSID(io::Error),
-    CouldNotDisconnect(io::Error),
-    CannotWriteStdout(io::Error),
-    CannotScanWiFi(io::Error),
-    InvalidSignalStrength,
+    CannotWriteBuffer(io::Error),
+    CannotFlushWriter(io::Error),
 }
-
-impl error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "will be implemented")
+        match self {
+            Error::CannotWriteBuffer(error) => todo!(),
+            Error::CannotFlushWriter(error) => todo!(),
+        }
     }
 }
+impl error::Error for Error {}
 
 pub fn new() -> impl adapter::Wl {
     nmcli::Nmcli::new()
 }
 
-fn write_out(mut f: impl io::Write, buf: &[u8]) -> Result<(), Error> {
-    f.write_all(buf).map_err(Error::CannotWriteStdout)
+fn write_bytes(f: &mut impl io::Write, buf: &[u8]) -> Result<(), Error> {
+    f.write_all(buf).map_err(Error::CannotWriteBuffer)?;
+    f.flush().map_err(Error::CannotFlushWriter)
 }

--- a/src/list_networks.rs
+++ b/src/list_networks.rs
@@ -1,12 +1,12 @@
 use std::{error, io};
 
 use crate::{
-    adapter::Wl,
+    adapter::{self, Wl},
     write_bytes,
 };
 
 pub fn list_networks(show_active: bool, show_ssid: bool) -> Result<(), Box<dyn error::Error>> {
-    let process = crate::new();
+    let process = adapter::new();
     let networks = process.list_networks(show_active, show_ssid)?;
 
     write_bytes(&mut io::stdout(), &networks)?;

--- a/src/list_networks.rs
+++ b/src/list_networks.rs
@@ -1,8 +1,14 @@
-use crate::{Error, adapter::Wl};
+use std::{error, io};
 
-pub fn list_networks(show_active: bool, show_ssid: bool) -> Result<(), Error> {
+use crate::{
+    adapter::Wl,
+    write_bytes,
+};
+
+pub fn list_networks(show_active: bool, show_ssid: bool) -> Result<(), Box<dyn error::Error>> {
     let process = crate::new();
-    process
-        .list_networks(show_active, show_ssid)
-        .map_err(Error::CannotListNetworks)
+    let networks = process.list_networks(show_active, show_ssid)?;
+
+    write_bytes(&mut io::stdout(), &networks)?;
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{error, io, os::unix::ffi::OsStringExt, process::ExitCode};
+use std::{error, io, process::ExitCode};
 
 use clap::Parser;
 use wl::api;
@@ -24,8 +24,7 @@ fn run() -> Result<(), Box<dyn error::Error>> {
         }
         api::WlCommand::Connect { ssid, force } => wl::connect(),
         api::WlCommand::Disconnect { ssid, forget } => {
-            let ssid = ssid.map(OsStringExt::into_vec);
-            wl::disconnect(ssid, forget)
+            wl::disconnect(ssid.map(|i| i.into_bytes()), forget)
         }
         api::WlCommand::ListNetworks {
             show_active,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,9 @@ fn run() -> Result<(), Box<dyn error::Error>> {
             let mut out_buf = io::stdout();
             wl::scan(&mut out_buf, args)
         }
-        api::WlCommand::Connect { ssid, force } => wl::connect(),
+        api::WlCommand::Connect { ssid, force_passwd } => {
+            wl::connect(ssid.map(|i| i.into_bytes()), force_passwd)
+        }
         api::WlCommand::Disconnect { ssid, forget } => {
             wl::disconnect(ssid.map(|i| i.into_bytes()), forget)
         }

--- a/src/nmcli.rs
+++ b/src/nmcli.rs
@@ -2,13 +2,13 @@ use std::{
     collections::HashMap,
     ffi::OsString,
     fmt,
-    io::{self, BufRead, Error, Write},
+    io::{self, BufRead},
     os::unix::ffi::OsStringExt,
     process::Command,
 };
 
 use crate::{
-    adapter::{CARRIAGE_RETURN, Decimal, LINE_FEED, SsidDevPair, Wl},
+    adapter::{CARRIAGE_RETURN, Decimal, Error, LINE_FEED, SsidDevPair, Wl},
     api,
 };
 
@@ -36,14 +36,14 @@ impl Nmcli {
         Self
     }
 
-    fn exec(&self, args: &[&[u8]]) -> Result<Vec<u8>, Error> {
+    fn exec(&self, args: &[&[u8]]) -> Result<Vec<u8>, io::Error> {
         let mut nmcli = Command::new("nmcli");
         let args = args.iter().map(|s| OsString::from_vec(s.to_vec()));
         let cmd = nmcli.args(args).output()?;
 
         if !cmd.status.success() {
-            let nmcli_err = cmd.stderr.lines().collect::<Result<String, Error>>()?;
-            return Err(Error::other(nmcli_err));
+            let nmcli_err = cmd.stderr.lines().collect::<Result<String, io::Error>>()?;
+            return Err(io::Error::other(nmcli_err));
         }
 
         Ok(cmd.stdout)
@@ -53,7 +53,7 @@ impl Nmcli {
 impl Wl for Nmcli {
     fn get_wifi_status(&self) -> Result<impl fmt::Display, Error> {
         let args = ["-g", "WIFI", "g"].map(|a| a.as_bytes());
-        let result = self.exec(&args)?;
+        let result = self.exec(&args).map_err(Error::CannotGetWiFiStatus)?;
 
         Ok(if &result[..] == b"enabled\n" {
             WiFiStatus::Enabled
@@ -76,7 +76,9 @@ impl Wl for Nmcli {
             WiFiStatus::Enabled
         };
 
-        let _ = self.exec(&args.map(|a| a.as_bytes()))?;
+        let _ = self
+            .exec(&args.map(|a| a.as_bytes()))
+            .map_err(Error::CannotToggleWiFi)?;
 
         Ok(new_status)
     }
@@ -84,7 +86,9 @@ impl Wl for Nmcli {
     fn get_active_ssid_dev_pairs(&self) -> Result<Vec<SsidDevPair>, Error> {
         let args = ["-g", "NAME,DEVICE", "connection", "show", "--active"];
 
-        let result = self.exec(&args.map(|a| a.as_bytes()))?;
+        let result = self
+            .exec(&args.map(|a| a.as_bytes()))
+            .map_err(Error::CannotGetActiveConnections)?;
 
         const NMCLI_FIELD_SEPARATOR: u8 = b':';
 
@@ -104,7 +108,7 @@ impl Wl for Nmcli {
             .collect::<Vec<SsidDevPair>>())
     }
 
-    fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<(), Error> {
+    fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<Vec<u8>, Error> {
         let mut args = ["", "", "connection", "show", ""];
 
         if show_ssid {
@@ -122,14 +126,16 @@ impl Wl for Nmcli {
             .map(|a| a.as_bytes())
             .collect();
 
-        let result = self.exec(&args)?;
-        io::stdout().write_all(&result)
+        let result = self.exec(&args).map_err(Error::CannotListNetworks)?;
+        Ok(result)
     }
 
     fn get_active_ssids(&self) -> Result<Vec<Vec<u8>>, Error> {
         let args = ["-g", "NAME", "connection", "show", "--active"];
 
-        let result = self.exec(&args.map(|a| a.as_bytes()))?;
+        let result = self
+            .exec(&args.map(|a| a.as_bytes()))
+            .map_err(Error::CannotGetSSIDStatus)?;
 
         Ok(result
             .split(|b| b == &LINE_FEED)
@@ -144,7 +150,7 @@ impl Wl for Nmcli {
             .collect())
     }
 
-    fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<(), Error> {
+    fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<Vec<u8>, Error> {
         let mut args = [
             "connection",
             if forget { "delete" } else { "down" },
@@ -152,14 +158,12 @@ impl Wl for Nmcli {
             "",
         ]
         .map(|a| a.as_bytes());
-
         args[3] = ssid;
 
-        let result = self.exec(&args)?;
-        io::stdout().write_all(&result[..])
+        self.exec(&args).map_err(Error::CannotDisconnect)
     }
 
-    fn scan(&self, args: &api::ScanArgs) -> Result<Vec<u8>, io::Error> {
+    fn scan(&self, args: &api::ScanArgs) -> Result<Vec<u8>, Error> {
         let mut nmcli_args = ["", "", "d", "wifi", "list", "", ""];
 
         let nmcli_global_args = match (&args.columns, &args.get_values) {
@@ -180,12 +184,14 @@ impl Wl for Nmcli {
             .map(|a| a.as_bytes())
             .collect();
 
-        let scan_result = self.exec(&nmcli_args)?;
+        let scan_result = self.exec(&nmcli_args).map_err(Error::CannotScanWiFi)?;
 
         let cloned_process = self.clone();
         let nmcli_args = ["-g", "SIGNAL", "d", "wifi", "list"];
 
-        let signal_result = cloned_process.exec(&nmcli_args.map(|a| a.as_bytes()))?;
+        let signal_result = cloned_process
+            .exec(&nmcli_args.map(|a| a.as_bytes()))
+            .map_err(Error::CannotScanWiFi)?;
         let signal_lines = signal_result
             .split(|b| b == &LINE_FEED)
             .map(|l| l.strip_suffix(&[CARRIAGE_RETURN]).unwrap_or(l))

--- a/src/nmcli.rs
+++ b/src/nmcli.rs
@@ -8,13 +8,11 @@ use std::{
 };
 
 use crate::{
-    adapter::{Decimal, SsidDevPair, Wl},
+    adapter::{CARRIAGE_RETURN, Decimal, LINE_FEED, SsidDevPair, Wl},
     api,
 };
 
 pub const LOOPBACK_INTERFACE_NAME: &[u8] = b"lo";
-const LINE_FEED: u8 = 0xA;
-const CARRIAGE_RETURN: u8 = 0xD;
 
 pub enum WiFiStatus {
     Enabled,

--- a/src/nmcli.rs
+++ b/src/nmcli.rs
@@ -209,4 +209,8 @@ impl Wl for Nmcli {
 
         Ok(filtered_scan)
     }
+
+    fn get_field_separator(&self) -> u8 {
+        b':'
+    }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,17 +1,32 @@
-use std::io;
+use std::{error, fmt, io};
 
 use crate::adapter::Wl;
 use crate::api::ScanArgs;
-use crate::{Error, write_out};
+use crate::write_bytes;
 
-pub fn scan(mut f: impl io::Write, args: ScanArgs) -> Result<(), Error> {
+#[derive(Debug)]
+pub enum Error {
+    InvalidSignalStrength,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // WARN: Implement the missing error messages.
+        match self {
+            Error::InvalidSignalStrength => todo!(),
+        }
+    }
+}
+impl error::Error for Error {}
+
+pub fn scan(f: &mut impl io::Write, args: ScanArgs) -> Result<(), Box<dyn error::Error>> {
     const MAX_SIGNAL_STRENGTH: u8 = 100u8;
 
     let 0u8..=MAX_SIGNAL_STRENGTH = &args.min_strength else {
-        return Err(Error::InvalidSignalStrength);
+        return Err(Error::InvalidSignalStrength)?;
     };
 
     let process = crate::new();
-    let result = process.scan(&args).map_err(Error::CannotScanWiFi)?;
-    write_out(&mut f, &result[..])
+    let result = process.scan(&args)?;
+    Ok(write_bytes(f, &result[..])?)
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,6 +1,6 @@
 use std::{error, fmt, io};
 
-use crate::adapter::Wl;
+use crate::adapter::{self, Wl};
 use crate::api::ScanArgs;
 use crate::write_bytes;
 
@@ -26,7 +26,7 @@ pub fn scan(f: &mut impl io::Write, args: ScanArgs) -> Result<(), Box<dyn error:
         return Err(Error::InvalidSignalStrength)?;
     };
 
-    let process = crate::new();
+    let process = adapter::new();
     let result = process.scan(&args)?;
     Ok(write_bytes(f, &result[..])?)
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,12 +1,12 @@
 use std::{error, io};
 
 use crate::{
-    adapter::Wl,
+    adapter::{self, Wl},
     write_bytes,
 };
 
 pub fn status() -> Result<(), Box<dyn error::Error>> {
-    let process = crate::new();
+    let process = adapter::new();
     let pairs = process.get_active_ssid_dev_pairs()?;
 
     let wifi_status = process.get_wifi_status()?;

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,28 +1,27 @@
-use std::io;
+use std::{error, io};
 
-use crate::{Error, adapter::Wl, write_out};
+use crate::{
+    adapter::Wl,
+    write_bytes,
+};
 
-pub fn status() -> Result<(), Error> {
+pub fn status() -> Result<(), Box<dyn error::Error>> {
     let process = crate::new();
-    let pairs = process
-        .get_active_ssid_dev_pairs()
-        .map_err(Error::CannotGetActiveConnections)?;
+    let pairs = process.get_active_ssid_dev_pairs()?;
 
-    let wifi_status = process
-        .get_wifi_status()
-        .map_err(Error::CannotGetWifiStatus)?;
+    let wifi_status = process.get_wifi_status()?;
 
     let mut stdout = io::stdout();
 
-    let out_buf = format!("wifi: {}\n", wifi_status);
-    write_out(&mut stdout, out_buf.as_bytes())?;
+    let out_buf = [b"wifi: ", &wifi_status[..], b" \n"].concat();
+    write_bytes(&mut stdout, &out_buf)?;
 
     let mut out_buf: Vec<u8> = b"connected networks: ".to_vec();
     for (ssid, dev) in pairs {
         let mut pair = [&ssid[..], b"/", &dev[..], b", "].concat();
         out_buf.append(&mut pair);
     }
-    write_out(&mut stdout, out_buf.strip_suffix(b", ").unwrap())?;
+    write_bytes(&mut stdout, out_buf.strip_suffix(b", ").unwrap())?;
 
     Ok(())
 }

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -1,13 +1,16 @@
-use std::io;
+use std::{error, io};
 
-use crate::{Error, adapter::Wl, write_out};
+use crate::{
+    adapter:: Wl,
+    write_bytes,
+};
 
-pub fn toggle() -> Result<(), Error> {
+pub fn toggle() -> Result<(), Box<dyn error::Error>> {
     let process = crate::new();
-    let toggled_status = process.toggle_wifi().map_err(Error::CannotToggleWifi)?;
+    let toggled_status = process.toggle_wifi()?;
 
-    let out_buf = format!("wifi: {}\n", toggled_status);
-    write_out(&mut io::stdout(), out_buf.as_bytes())?;
+    let out_buf = [b"wifi: ", &toggled_status[..], b" \n"].concat();
+    write_bytes(&mut io::stdout(), &out_buf)?;
 
     Ok(())
 }

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -1,12 +1,12 @@
 use std::{error, io};
 
 use crate::{
-    adapter:: Wl,
+    adapter::{self, Wl},
     write_bytes,
 };
 
 pub fn toggle() -> Result<(), Box<dyn error::Error>> {
-    let process = crate::new();
+    let process = adapter::new();
     let toggled_status = process.toggle_wifi()?;
 
     let out_buf = [b"wifi: ", &toggled_status[..], b" \n"].concat();


### PR DESCRIPTION
`wl connect` (or `wl c` with alias) is designed to connect to both an existing network or a new one.

It is also designed to handle the unintuitive way of entering the SSID's by hand by providing an interactive mode.
If the SSID is not given by the user, then `wl c` shows a list of available networks with their signal strengths to choose from.

It is also designed refresh the network connection for the cases when the password of the network changes by using `--force-passwd`.

### Other changes

During the development of `wl connect`, the things below are observed and fixed accordingly. Each can be checked in detail from their corresponding commits.

- [Errors](https://github.com/acikgozb/wl/commit/b285fe5cc58272495a6dfb3d597d6b216a5bbbd5): At first, due to the simplicity of the error cases, the errors were defined in the lib root. However, as project grew, the lib root started to hold all errors related with both the network backends and the actual `wl` subcommand functionality.
Therefore, subcommand related errors are moved to subcommand modules, and network backend related ones are moved under the adapter module.

- [Line feeds](https://github.com/acikgozb/wl/commit/21ae299462cbebab738405d5ca351a2e74809a6f): At first, line feed and carriage return bytes were defined under the network backend, but when the output parsing came into the play, the subcommand modules needed to use them as well. 
Therefore, they are moved under the adapter module.

- [Network backend initialization](https://github.com/acikgozb/wl/commit/e1963a22970fbb600d358c21a2163b4e47dfe3f3): The library root is further divided by moving the network backend related functionality under the adapter module.

- [WiFi status responses](https://github.com/acikgozb/wl/commit/543caa8648a74f08cbe679d841cbfb98b6513a66): When the SSID's came into the play, most of the subcommands are changed to work on bytes instead of UTF-8 strings. However, WiFi status related subcommands were still functioning over UTF-8.
To be in sync with the other methods in `adapter::Wl`, the status methods are updated to use `Vec<u8>` as well.

- [Field separators](https://github.com/acikgozb/wl/commit/6fc48adb9e59b64abc8f1836dafcb30b556e6815): The separator bytes used by each network backend (for their terse outputs) are put under the adapter module. This is done to parse the output in the subcommand modules and to prevent implementing every single parsing under the network backend (`nmcli`).


