### PR TITLE
feat(diagnostics): Add diagnostics with err codes

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -31,20 +31,41 @@ pub fn new() -> impl Wl {
 
 #[derive(Debug)]
 pub enum Error {
-    CannotGetWiFiStatus(io::Error),
-    CannotToggleWiFi(io::Error),
-    CannotListNetworks(io::Error),
-    CannotGetActiveConnections(io::Error),
-    CannotGetSSIDStatus(io::Error),
-    CannotDisconnect(io::Error),
-    CannotScanWiFi(io::Error),
-    CannotConnect(io::Error),
+    CannotGetWiFiStatus((io::Error, i32)),
+    CannotToggleWiFi((io::Error, i32)),
+    CannotListNetworks((io::Error, i32)),
+    CannotGetActiveConnections((io::Error, i32)),
+    CannotGetSSIDStatus((io::Error, i32)),
+    CannotDisconnect((io::Error, i32)),
+    CannotScanWiFi((io::Error, i32)),
+    CannotConnect((io::Error, i32)),
 }
 
 impl error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "will be implemented")
+        match self {
+            Error::CannotGetWiFiStatus((err, _)) => {
+                write!(f, "unable to get the WiFi status: {}", err)
+            }
+            Error::CannotToggleWiFi((err, _)) => write!(f, "unable to toggle WiFi: {}", err),
+            Error::CannotListNetworks((err, _)) => {
+                write!(f, "unable to list the networks: {}", err)
+            }
+            Error::CannotGetActiveConnections((err, _)) => {
+                write!(f, "unable to get the active connections: {}", err)
+            }
+            Error::CannotGetSSIDStatus((err, _)) => {
+                write!(f, "unable to get the SSID status: {}", err)
+            }
+            Error::CannotDisconnect((err, _)) => write!(f, "unable to disconnect: {}", err),
+            Error::CannotScanWiFi((err, _)) => {
+                write!(f, "unable to scan the available networks: {}", err)
+            }
+            Error::CannotConnect((err, _)) => {
+                write!(f, "unable to connect to the network: {}", err)
+            }
+        }
     }
 }
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -20,10 +20,12 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // WARN: Implement the missing error messages.
         match self {
-            Error::CannotReadPasswd(error) => todo!(),
-            Error::CannotReadSSID(error) => todo!(),
+            Error::CannotReadPasswd(err) => write!(f, "cannot read passwd from stdin: {}", err),
+            Error::CannotReadSSID(err) => match err {
+                Some(err) => write!(f, "unable to get the SSID: {}", err),
+                None => write!(f, "the given SSID does not exist on the list"),
+            },
         }
     }
 }

--- a/src/disconnect.rs
+++ b/src/disconnect.rs
@@ -11,9 +11,11 @@ pub enum Error {
 }
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // WARN: Implement the missing error messages.
         match self {
-            Error::InvalidActiveSSID(_) => todo!(),
+            Error::InvalidActiveSSID(err) => match err {
+                Some(err) => write!(f, "unable to get the active SSID: {}", err),
+                None => write!(f, "unable to get the active SSID"),
+            },
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,7 @@ mod scan;
 mod status;
 mod toggle;
 
-use std::{
-    error, fmt,
-    io::{self, Write},
-};
-
+pub use adapter::Error as NetworkAdapterError;
 pub use connect::connect;
 pub use disconnect::disconnect;
 pub use list_networks::list_networks;
@@ -30,8 +26,12 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::CannotWriteBuffer(error) => todo!(),
-            Error::CannotFlushWriter(error) => todo!(),
+            Error::CannotWriteBuffer(err) => {
+                write!(f, "unable to write to the output stream: {}", err)
+            }
+            Error::CannotFlushWriter(err) => {
+                write!(f, "unable to flush the output stream: {}", err)
+            }
         }
     }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -6,14 +6,17 @@ use crate::write_bytes;
 
 #[derive(Debug)]
 pub enum Error {
-    InvalidSignalStrength,
+    InvalidSignalStrength(u8),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // WARN: Implement the missing error messages.
         match self {
-            Error::InvalidSignalStrength => todo!(),
+            Error::InvalidSignalStrength(s) => write!(
+                f,
+                "the given signal strength {} is not in limits (1..100)",
+                s
+            ),
         }
     }
 }
@@ -23,7 +26,7 @@ pub fn scan(f: &mut impl io::Write, args: ScanArgs) -> Result<(), Box<dyn error:
     const MAX_SIGNAL_STRENGTH: u8 = 100u8;
 
     let 0u8..=MAX_SIGNAL_STRENGTH = &args.min_strength else {
-        return Err(Error::InvalidSignalStrength)?;
+        return Err(Error::InvalidSignalStrength(args.min_strength))?;
     };
 
     let process = adapter::new();


### PR DESCRIPTION
Error messages are added for all possible errors coming out from `wl`.

Also, exit codes of the network backends' are obtained and left untouched in `wl` to provide the same behavior to the users as using the backend by itself.