### PR TITLE
chore(adapter): Remove output parsing in net BE

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -4,16 +4,15 @@ use crate::{api::ScanArgs, nmcli};
 
 pub const LINE_FEED: u8 = 0xA;
 pub const CARRIAGE_RETURN: u8 = 0xD;
-
-pub type SsidDevPair = (Vec<u8>, Vec<u8>);
+pub const LOOPBACK_INTERFACE_NAME: &[u8] = b"lo";
 
 pub trait Wl {
     fn get_field_separator(&self) -> u8;
     fn get_wifi_status(&self) -> Result<Vec<u8>, Error>;
     fn toggle_wifi(&self) -> Result<Vec<u8>, Error>;
     fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<Vec<u8>, Error>;
-    fn get_active_ssid_dev_pairs(&self) -> Result<Vec<SsidDevPair>, Error>;
-    fn get_active_ssids(&self) -> Result<Vec<Vec<u8>>, Error>;
+    fn get_active_ssid_dev_pairs(&self) -> Result<Vec<u8>, Error>;
+    fn get_active_ssids(&self) -> Result<Vec<u8>, Error>;
     fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<Vec<u8>, Error>;
     fn scan(&self, args: &ScanArgs) -> Result<Vec<u8>, Error>;
     fn is_known_ssid(&self, ssid: &[u8]) -> Result<bool, Error>;

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,27 +1,57 @@
 use std::{error, io};
 
 use crate::{
-    adapter::{self, Wl},
+    adapter::{self, CARRIAGE_RETURN, LINE_FEED},
     write_bytes,
 };
 
 pub fn status() -> Result<(), Box<dyn error::Error>> {
+    let mut stdout = io::stdout();
     let process = adapter::new();
-    let pairs = process.get_active_ssid_dev_pairs()?;
 
+    write_wifi_status(&mut stdout, &process)?;
+    write_active_ssid_dev_pairs(&mut stdout, &process)?;
+    Ok(())
+}
+
+fn write_wifi_status(
+    f: &mut impl io::Write,
+    process: &impl adapter::Wl,
+) -> Result<(), Box<dyn error::Error>> {
     let wifi_status = process.get_wifi_status()?;
 
-    let mut stdout = io::stdout();
+    let wifi_status = [b"wifi: ", &wifi_status[..], b" \n"].concat();
+    write_bytes(f, &wifi_status)?;
+    Ok(())
+}
 
-    let out_buf = [b"wifi: ", &wifi_status[..], b" \n"].concat();
-    write_bytes(&mut stdout, &out_buf)?;
+fn write_active_ssid_dev_pairs(
+    f: &mut impl io::Write,
+    process: &impl adapter::Wl,
+) -> Result<(), Box<dyn error::Error>> {
+    let pairs = process.get_active_ssid_dev_pairs()?;
+    let field_separator = process.get_field_separator();
 
-    let mut out_buf: Vec<u8> = b"connected networks: ".to_vec();
-    for (ssid, dev) in pairs {
+    let pair_iter = pairs.split(|b| b == &LINE_FEED).filter_map(|s| {
+        let line = s.strip_suffix(&[CARRIAGE_RETURN]).unwrap_or(s);
+
+        if line.is_empty() {
+            None
+        } else {
+            let pair = line
+                .split(|b| b == &field_separator)
+                .collect::<Vec<&[u8]>>();
+
+            Some((pair[0].to_vec(), pair[1].to_vec()))
+        }
+    });
+
+    let mut active_ssid_dev_pairs = ["connected networks: ".as_bytes()].concat();
+    for (ssid, dev) in pair_iter {
         let mut pair = [&ssid[..], b"/", &dev[..], b", "].concat();
-        out_buf.append(&mut pair);
+        active_ssid_dev_pairs.append(&mut pair);
     }
-    write_bytes(&mut stdout, out_buf.strip_suffix(b", ").unwrap())?;
+    write_bytes(f, active_ssid_dev_pairs.strip_suffix(b", ").unwrap())?;
 
     Ok(())
 }


### PR DESCRIPTION
Some of the parsing done on the `adapter::Wl` methods are removed to the appropriate subcommand modules.

This is done to remove extra, unnecessary allocations & work being done inside the network backend modules.