### PR TITLE
feat(api): Rename short flags

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -43,10 +43,11 @@ pub enum WlCommand {
     #[clap(visible_alias = "d")]
     Disconnect {
         /// Forget the network (delete it from the known network list).
-        #[arg(short = 'f', long, default_value_t = false)]
+        #[arg(short, long, default_value_t = false)]
         forget: bool,
 
         /// SSID of the target network.
+        #[arg(short = 'i', long)]
         ssid: Option<String>,
     },
 
@@ -58,7 +59,7 @@ pub enum WlCommand {
         show_active: bool,
 
         /// Output the SSID's only.
-        #[arg(short = 's', long = "ssid", default_value_t = false)]
+        #[arg(short = 'i', long = "ssid", default_value_t = false)]
         show_ssid: bool,
     },
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -47,6 +47,9 @@ pub enum WlCommand {
         forget: bool,
 
         /// SSID of the target network.
+        ///
+        /// If the SSID is not provided, then the program will show
+        /// a list of the connected networks to the user to choose from.
         #[arg(short = 'i', long)]
         ssid: Option<String>,
     },
@@ -66,19 +69,30 @@ pub enum WlCommand {
 
 #[derive(clap::Args, Debug)]
 pub struct ScanArgs {
-    /// Filter scan list based on minimum WiFi signal strength (0 to 100).
+    /// Filter scan list based on minimum WiFi signal strength.
     #[arg(short = 's', long, default_value_t = 0)]
     pub min_strength: u8,
 
     /// Bypass cache and force a re-scan.
+    ///
+    /// The re-scanning behavior depends on the underlying network backend.
+    /// `wl` does not have a custom re-scan.
     #[arg(short = 'r', long, default_value_t = false)]
     pub re_scan: bool,
 
-    /// Show specified columns only.
+    /// Only show the specified columns of a network scan.
+    ///
+    /// This option is useful for filtering the table by column names.
+    /// Compared to `--get-values`, the output contains an extra line for
+    /// table columns.
     #[arg(short = 'c', long, conflicts_with = "get_values")]
     pub columns: Option<String>,
 
     /// Show values of specified fields (terse output).
+    ///
+    /// This option is useful for scripting purposes.
+    /// Compared to `--columns`, the output does not contain an extra
+    /// line for table columns.
     #[arg(short = 'g', long)]
     pub get_values: Option<String>,
 }


### PR DESCRIPTION
Short version of the flags are updated to be in sync across the subcommands.

### Other Changes

Doc comments are improved to add clarity to some of the subcommand arguments.

These extra informations are shown when `wl --help` is called. `wl -h` only shows the first line instead.
