### PR TITLE
docs(wl): Add doc comments

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -2,20 +2,93 @@ use std::{error, fmt, io};
 
 use crate::{api::ScanArgs, nmcli};
 
+/// Represents the line feed byte that can be used to split
+/// a byte slice into lines.
+///
+/// Some programs represent lines by appending both the line feed
+/// and the carriage return bytes.
+/// To ensure that the byte slice is splitted into lines, use this
+/// along with [`CARRIAGE_RETURN`].
+///
+/// [`CARRIAGE_RETURN`] - crate::adapter::CARRIAGE_RETURN
 pub const LINE_FEED: u8 = 0xA;
+
+/// Represents the carriage return byte that can be used to split
+/// a byte slice into lines.
+///
+/// Some programs represent lines by appending both the line feed
+/// and the carriage return bytes.
+/// To ensure that the byte slice is splitted into lines, use this
+/// along with [`LINE_FEED`].
+///
+/// [`LINE_FEED`] - crate::adapter::LINE_FEED
 pub const CARRIAGE_RETURN: u8 = 0xD;
+
+/// Represents the loopback interface name.
+///
+/// Some network backends contain the loopback interface in their output.
+/// If needed, this can be used to filter out the interface from the output.
 pub const LOOPBACK_INTERFACE_NAME: &[u8] = b"lo";
 
+/// The main interface that should be implemented by all network backends.
+///
+/// Methods of this trait represent the core functionality that should be provided by each network backend.
+///
+/// The implementors of `Wl` may or may not encode their Ok result - it depends on the functionality of each individual method.
+///
+/// The callers of `Wl` should not assume anything about the return format other than being a byte stream. The format may differ for each method, and the implementors should document them wherever possible.
+///
+/// If a method returns a terse output for scripting purposes, then the implementor should mention it.
+///
+/// To see the available Error's, check out [`Error`].
+///
+/// [`Error`]: crate::adapter::Error
 pub trait Wl {
+    /// Provides the byte that is used for terse outputs.
+    ///
+    /// The byte that is returned from this method should be the one that is used in terse outputs that are returned from other methods to ensure that caller can rely on this method.
     fn get_field_separator(&self) -> u8;
+
+    /// Provides the WiFi status.
     fn get_wifi_status(&self) -> Result<Vec<u8>, Error>;
+
+    /// Toggles the WiFi status.
     fn toggle_wifi(&self) -> Result<Vec<u8>, Error>;
+
+    /// Lists the known networks on the host.
     fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<Vec<u8>, Error>;
+
+    /// Provides a stream of SSID-Device pairs.
     fn get_active_ssid_dev_pairs(&self) -> Result<Vec<u8>, Error>;
+
+    /// Provides a stream of active SSID's - aka. connected networks.
     fn get_active_ssids(&self) -> Result<Vec<u8>, Error>;
+
+    /// Disconnects the host from the given SSID.
+    ///
+    /// If `forget` is set, then this method removes the given SSID from the known network list of the host.
     fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<Vec<u8>, Error>;
+
+    /// Provides a stream of networks that can be connected.
+    ///
+    /// The implementors of this method should be able to provide both
+    /// human-readable and terse output.
+    ///
+    /// The values of [`ScanArgs`] may differ between each network backend.
+    /// The implementors should document the available options for callers.
+    ///
+    /// [`ScanArgs`]: crate::api::ScanArgs
     fn scan(&self, args: &ScanArgs) -> Result<Vec<u8>, Error>;
+
+    /// Provides whether the given SSID exists under the known network list
+    /// of the host or not.
     fn is_known_ssid(&self, ssid: &[u8]) -> Result<bool, Error>;
+
+    /// Connects the host to the given SSID.
+    ///
+    /// The implementors should validate whether the given SSID-password
+    /// pair is valid or not.
+    /// The callers are responsible from providing the SSID-password pair to the implementors.
     fn connect(
         &self,
         ssid: &[u8],
@@ -24,10 +97,20 @@ pub trait Wl {
     ) -> Result<Vec<u8>, Error>;
 }
 
+/// Initializes a new network backend adapter to the caller.
+///
+/// If the network backend relies on an external program, this
+/// function does not validate the existence of that external program.
 pub fn new() -> impl Wl {
     nmcli::Nmcli::new()
 }
 
+/// The main Error that is returned from the implementors of `Wl`.
+///
+/// The variants have 3 things:
+/// - A high level context about the error.
+/// - A detailed error about the underlying functionality.
+/// - An exit code that can be used to terminate the caller.
 #[derive(Debug)]
 pub enum Error {
     CannotGetWiFiStatus((io::Error, i32)),
@@ -68,6 +151,24 @@ impl fmt::Display for Error {
     }
 }
 
+/// A wrapper type of u8.
+///
+///
+/// It is designed to convert the given byte into its decimal representation.
+/// Implements [`From<&[u8]>`].
+///
+/// # Example
+///
+/// ```
+/// use wl::Decimal;
+///
+/// let dec = 5;
+/// let byte = b"5".as_slice();
+///
+/// assert_eq!(dec, Decimal::from(byte).inner())
+/// ```
+///
+/// [`From<&[u8]>`]: std::convert::From
 pub struct Decimal(u8);
 
 impl From<&[u8]> for Decimal {
@@ -77,6 +178,7 @@ impl From<&[u8]> for Decimal {
 }
 
 impl Decimal {
+    /// Provides the underlying decimal value to the caller.
     pub fn inner(&self) -> u8 {
         self.0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,14 @@ mod scan;
 mod status;
 mod toggle;
 
-pub use adapter::Error as NetworkAdapterError;
-pub use connect::connect;
-pub use disconnect::disconnect;
+pub use adapter::{
+    CARRIAGE_RETURN, Decimal, Error as NetworkAdapterError, LINE_FEED, LOOPBACK_INTERFACE_NAME, Wl,
+};
+pub use connect::{Error as ConnectError, connect};
+pub use disconnect::{Error as DisconnectError, disconnect};
 pub use list_networks::list_networks;
-pub use scan::scan;
+pub use nmcli::Nmcli;
+pub use scan::{Error as ScanError, scan};
 pub use status::status;
 pub use toggle::toggle;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,28 +19,9 @@ pub use scan::{Error as ScanError, scan};
 pub use status::status;
 pub use toggle::toggle;
 
-use std::{error, fmt, io};
+use std::io;
 
-#[derive(Debug)]
-pub enum Error {
-    CannotWriteBuffer(io::Error),
-    CannotFlushWriter(io::Error),
-}
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::CannotWriteBuffer(err) => {
-                write!(f, "unable to write to the output stream: {}", err)
-            }
-            Error::CannotFlushWriter(err) => {
-                write!(f, "unable to flush the output stream: {}", err)
-            }
-        }
-    }
-}
-impl error::Error for Error {}
-
-fn write_bytes(f: &mut impl io::Write, buf: &[u8]) -> Result<(), Error> {
-    f.write_all(buf).map_err(Error::CannotWriteBuffer)?;
-    f.flush().map_err(Error::CannotFlushWriter)
+fn write_bytes(f: &mut impl io::Write, buf: &[u8]) -> Result<(), io::Error> {
+    f.write_all(buf)?;
+    f.flush()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,29 @@
+//! A simple wrapper around network backend programs, designed to provide a simple interface for host WiFi management.
+//!
+//! The WiFi functionality it exposes are executed by the network backends.
+//! Here is a list of network backends that are supported:
+//!
+//! - [`nmcli`] (NetworkManager)
+//!
+//! To see the interface for each network backend, check out the [`Wl`] trait.
+//! To see the available functionality, check out the corresponding functions below:
+//!
+//! - [`status`]
+//! - [`toggle`]
+//! - [`list_networks`]
+//! - [`scan`]
+//! - [`connect`]
+//! - [`disconnect`]
+//!
+//! [`nmcli`]: crate::Nmcli
+//! [`Wl`]: crate::Wl
+//! [`status`]: crate::status
+//! [`toggle`]: crate::toggle
+//! [`list_networks`]: crate::list_networks
+//! [`scan`]: crate::scan
+//! [`connect`]: crate::connect
+//! [`disconnect`]: crate::disconnect
+
 mod adapter;
 pub mod api;
 mod connect;

--- a/src/list_networks.rs
+++ b/src/list_networks.rs
@@ -5,6 +5,28 @@ use crate::{
     write_bytes,
 };
 
+/// Provides the list of known WiFi networks by using a [`Wl`] implementation.
+/// To see the available networks to connect, please refer to [`scan`] instead.
+///
+/// The list is written to stdout stream.
+///
+/// The default list format depends on the [`Wl`] implementation.
+/// If desired, the list can be filtered in two different ways:
+///
+/// - By showing the SSIDs only,
+/// - By showing the active network connections only.
+///
+/// # Panics
+///
+/// This function does not panic.
+///
+/// # Errors
+///
+/// This function can return an [`adapter::Error`] when the underlying [`Wl`] implementation fails or [`io::Error`] when the information cannot be written on the stdout stream.
+///
+/// [`adapter::Error`]: crate::adapter::Error
+/// [`io::Error`]: std::io::Error
+/// [`scan`]: crate::scan
 pub fn list_networks(show_active: bool, show_ssid: bool) -> Result<(), Box<dyn error::Error>> {
     let process = adapter::new();
     let networks = process.list_networks(show_active, show_ssid)?;

--- a/src/nmcli.rs
+++ b/src/nmcli.rs
@@ -11,10 +11,21 @@ use crate::{
     api,
 };
 
-#[derive(Clone)]
+/// The adapter struct that implements [`Wl`] by using `nmcli`.
+///
+/// Since the struct can be changed in future versions, always
+/// prefer to initialize it by using [`Nmcli::new`] instead.
+///
+/// [`Wl`]: crate::Wl
+/// [`Nmcli::new`]: crate::Nmcli::new
+#[derive(Clone, Default)]
 pub struct Nmcli;
 
 impl Nmcli {
+    /// Creates a new `Nmcli` instance.
+    ///
+    /// The instance created by `new` can be reused multiple times
+    /// in a given context. It can also be cloned freely.
     pub fn new() -> Self {
         Self
     }
@@ -43,6 +54,31 @@ impl Nmcli {
 }
 
 impl Wl for Nmcli {
+    /// Provides the WiFi status.
+    ///
+    /// It returns the WiFi status that is in a **human-readable format** and is a single line.
+    ///
+    /// # Panics
+    ///
+    /// This method does not panic.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`NetworkAdapterError::CannotGetWiFiStatus`] when it fails
+    /// to obtain the WiFi status.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wl::{Nmcli,Wl};
+    /// use std::io::{self, Write};
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let status = nmcli.get_wifi_status().unwrap();
+    /// io::stdout().write_all(&status).unwrap();
+    /// ```
+    ///
+    /// [`NetworkAdapterError::CannotGetWiFiStatus`]: crate::NetworkAdapterError::CannotGetWiFiStatus
     fn get_wifi_status(&self) -> Result<Vec<u8>, Error> {
         let args = ["-g", "WIFI", "g"].map(|a| a.as_bytes());
         let result = self.exec(&args).map_err(Error::CannotGetWiFiStatus)?;
@@ -54,6 +90,31 @@ impl Wl for Nmcli {
             .collect())
     }
 
+    /// Toggles the WiFi status.
+    ///
+    /// It returns the updated WiFi status in a **human-readable format** within a single line.
+    ///
+    /// # Panics
+    ///
+    /// This method does not panic.
+    ///
+    /// # Errors
+    ///
+    /// This method can return either a [`NetworkAdapterError::CannotGetWiFiStatus`] or a [`NetworkAdapterError::CannotToggleWiFi`] when it fails to toggle WiFi.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wl::{Nmcli,Wl};
+    /// use std::io::{self, Write};
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let updated_status = nmcli.toggle_wifi().unwrap();
+    /// io::stdout().write_all(&updated_status).unwrap();
+    /// ```
+    ///
+    /// [`NetworkAdapterError::CannotGetWiFiStatus`]: crate::NetworkAdapterError::CannotGetWiFiStatus
+    /// [`NetworkAdapterError::CannotToggleWiFi`]: crate::NetworkAdapterError::CannotToggleWiFi
     fn toggle_wifi(&self) -> Result<Vec<u8>, Error> {
         let cloned_process = self.clone();
         let prev_status = cloned_process.get_wifi_status()?;
@@ -75,6 +136,32 @@ impl Wl for Nmcli {
         Ok(new_status)
     }
 
+    /// Provides a list of SSID-Device pairs.
+    ///
+    /// The output is in a **terse format**.
+    /// To parse the output, [`get_field_separator`] can be used to split each element to get the SSID and the device.
+    ///
+    /// # Panics
+    ///
+    /// This method does not panic.
+    ///
+    /// # Errors
+    ///
+    /// This method returns a [`NetworkAdapterError::CannotGetActiveConnections`] when it fails to retrieve the pairs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wl::{Nmcli,Wl};
+    /// use std::io::{self, Write};
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let pairs = nmcli.get_active_ssid_dev_pairs().unwrap();
+    /// io::stdout().write_all(&pairs).unwrap();
+    /// ```
+    ///
+    /// [`get_field_separator`]: crate::Wl::get_field_separator
+    /// [`NetworkAdapterError::CannotGetActiveConnections`]: crate::NetworkAdapterError::CannotGetActiveConnections
     fn get_active_ssid_dev_pairs(&self) -> Result<Vec<u8>, Error> {
         let args = ["-g", "NAME,DEVICE", "connection", "show", "--active"];
 
@@ -82,6 +169,43 @@ impl Wl for Nmcli {
             .map_err(Error::CannotGetActiveConnections)
     }
 
+    /// Provides a list of known networks on the host.
+    ///
+    /// The output is in a **human-readable format**.
+    ///
+    /// # Panics
+    ///
+    /// This method does not panic.
+    ///
+    /// # Errors
+    ///
+    /// This method returns a [`NetworkAdapterError::CannotListNetworks`] when it fails to retrieve the pairs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wl::{Nmcli,Wl};
+    /// use std::io::{self, Write};
+    ///
+    /// let nmcli = Nmcli::new();
+    ///
+    /// // By default, it returns the whole list:
+    /// let net_list = nmcli.list_networks(false, false).unwrap();
+    ///
+    /// // `show_active` can be used to show the active connections on the host.
+    /// let net_list = nmcli.list_networks(true, false).unwrap();
+    ///
+    /// // `show_ssid` can be used to only show the SSIDs of the known networks.
+    /// let net_list = nmcli.list_networks(false, true).unwrap();
+    ///
+    /// // Both args can be used to only show the SSIDs of active connections in the known networks.
+    /// let net_list = nmcli.list_networks(true, true).unwrap();
+    ///
+    ///
+    /// io::stdout().write_all(&net_list).unwrap();
+    /// ```
+    ///
+    /// [`NetworkAdapterError::CannotListNetworks`]: crate::NetworkAdapterError::CannotListNetworks    
     fn list_networks(&self, show_active: bool, show_ssid: bool) -> Result<Vec<u8>, Error> {
         let mut args = ["", "", "connection", "show", ""];
 
@@ -103,6 +227,29 @@ impl Wl for Nmcli {
         self.exec(&args).map_err(Error::CannotListNetworks)
     }
 
+    /// Provides a list of active SSIDs on the host.
+    ///
+    /// The output is in a **terse format** and may contain multiple lines.
+    ///
+    /// # Panics
+    ///
+    /// This method does not panic.
+    ///
+    /// # Errors
+    ///
+    /// This method returns a [`NetworkAdapterError::CannotGetSSIDStatus`] when it fails to retrieve the SSIDs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wl::{Nmcli,Wl};
+    /// use std::io::{self, Write};
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let active_ssids = nmcli.get_active_ssids().unwrap();
+    /// io::stdout().write_all(&active_ssids).unwrap();
+    /// ```
+    /// [`NetworkAdapterError::CannotGetSSIDStatus`]: crate::NetworkAdapterError::CannotGetSSIDStatus
     fn get_active_ssids(&self) -> Result<Vec<u8>, Error> {
         let args = ["-g", "NAME", "connection", "show", "--active"];
 
@@ -110,6 +257,54 @@ impl Wl for Nmcli {
             .map_err(Error::CannotGetSSIDStatus)
     }
 
+    /// Disconnects from the given SSID.
+    ///
+    /// The output is in a **human-readable format**.
+    ///
+    /// # Panics
+    ///
+    /// This method does not panic.
+    ///
+    /// # Errors
+    ///
+    /// This method returns a [`NetworkAdapterError::CannotDisconnect`] when it fails to disconnect.
+    ///
+    /// # Examples
+    ///
+    /// Without `forget`, disconnect just disconnects from the SSID.
+    /// ```
+    /// use wl::{Nmcli,Wl};
+    /// use std::io::{self, Write};
+    ///
+    /// let ssid = "SSID";
+    /// let forget = false;
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let result = nmcli.disconnect(ssid.as_bytes(), forget);
+    /// match result {
+    ///     Ok(result) => io::stdout().write_all(&result).unwrap(),
+    ///     Err(err) => eprintln!("err during disconnect: {}", err),
+    /// }
+    /// ```
+    ///
+    /// Set `forget` to delete the SSID after disconnecting.
+    /// ```
+    /// use wl::{Nmcli,Wl};
+    /// use std::io::{self, Write};
+    ///
+    /// let ssid = "SSID";
+    /// let forget = true;
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let result = nmcli.disconnect(ssid.as_bytes(), forget);
+    ///
+    /// match result {
+    ///     Ok(result) => io::stdout().write_all(&result).unwrap(),
+    ///     Err(err) => eprintln!("err during disconnect: {}", err),
+    /// }
+    /// ```
+    ///
+    /// [`NetworkAdapterError::CannotDisconnect`]: crate::NetworkAdapterError::CannotDisconnect
     fn disconnect(&self, ssid: &[u8], forget: bool) -> Result<Vec<u8>, Error> {
         let mut args = [
             "connection",
@@ -123,6 +318,101 @@ impl Wl for Nmcli {
         self.exec(&args).map_err(Error::CannotDisconnect)
     }
 
+    /// Scan the available SSIDs to connect.
+    ///
+    /// The output depends on the [`ScanArgs`]:
+    ///
+    /// - If `columns` is used, then the output is in a **human-readable format** and may contain multiple lines.
+    /// - If `get_values` is used, then the output is in a **terse format** and may contain multiple lines. In this case, each line element contains FIELDS that are separated by [`get_field_separator`].
+    /// - Using `columns` overrides `get_values`.
+    ///
+    /// `columns` and `get_values` both use the same values as `nmcli -f FIELDS` and `nmcli -g FIELDS` respectively, which are comma separated values of column names.
+    ///
+    /// If `re-scan` is set, then `scan` refreshes the underlying cache of available networks.
+    ///
+    /// If `min_strength` is provided, the `scan` filters the list by the given signal strength.
+    ///
+    /// # Panics
+    ///
+    /// This method does not panic.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`NetworkAdapterError::CannotScanWiFi`] if it fails to scan the available networks.
+    ///
+    /// # Examples
+    ///
+    /// Use `columns` to get the scan result in a human-readable format.
+    /// ```
+    /// use wl::{Nmcli,Wl, api::ScanArgs};
+    /// use std::io::{self, Write};
+    ///
+    /// let args = ScanArgs {
+    ///     min_strength: 0,
+    ///     re_scan: false,
+    ///     get_values: None,
+    ///     columns: Some(String::from("SSID,SIGNAL")),
+    /// };
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let scan_result = nmcli.scan(&args).unwrap();
+    /// io::stdout().write_all(&scan_result).unwrap();
+    /// ```
+    ///
+    /// Use `get_values` to get the scan result in a terse format.
+    /// ```
+    /// use wl::{Nmcli,Wl, api::ScanArgs};
+    /// use std::io::{self, Write};
+    ///
+    /// let args = ScanArgs {
+    ///     min_strength: 0,
+    ///     re_scan: false,
+    ///     columns: None,
+    ///     get_values: Some(String::from("SSID,SIGNAL")),
+    /// };
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let scan_result = nmcli.scan(&args).unwrap();
+    /// io::stdout().write_all(&scan_result).unwrap();
+    /// ```
+    ///
+    /// Use `min_strength` to filter the scan list by SIGNAL.
+    /// ```
+    /// use wl::{Nmcli,Wl, api::ScanArgs};
+    /// use std::io::{self, Write};
+    ///
+    /// let args = ScanArgs {
+    ///     min_strength: 60,
+    ///     re_scan: false,
+    ///     columns: None,
+    ///     get_values: Some(String::from("SSID,SIGNAL")),
+    /// };
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let scan_result = nmcli.scan(&args).unwrap();
+    /// io::stdout().write_all(&scan_result).unwrap();
+    /// ```
+    ///
+    /// Use `re_scan` to refresh the scan cache.
+    /// ```
+    /// use wl::{Nmcli,Wl, api::ScanArgs};
+    /// use std::io::{self, Write};
+    ///
+    /// let args = ScanArgs {
+    ///     min_strength: 0,
+    ///     re_scan: true,
+    ///     columns: None,
+    ///     get_values: Some(String::from("SSID,SIGNAL")),
+    /// };
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let scan_result = nmcli.scan(&args).unwrap();
+    /// io::stdout().write_all(&scan_result).unwrap();
+    /// ```
+    ///
+    /// [`NetworkAdapterError::CannotScanWiFi`]: crate::NetworkAdapterError::CannotScanWiFi
+    /// [`ScanArgs`]: crate::api::ScanArgs
+    /// [`get_field_separator`]: crate::Nmcli::get_field_separator
     fn scan(&self, args: &api::ScanArgs) -> Result<Vec<u8>, Error> {
         let mut nmcli_args = ["", "", "d", "wifi", "list", "", ""];
 
@@ -184,6 +474,33 @@ impl Wl for Nmcli {
         Ok(filtered_scan)
     }
 
+    /// Checks whether the given SSID is a known one or not.
+    ///
+    /// # Panics
+    ///
+    /// This method does not panic.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`NetworkAdapterError::CannotGetSSIDStatus`] if it fails to check the SSID.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wl::{Nmcli,Wl};
+    /// use std::io::{self, Write};
+    ///
+    /// let ssid = "SSID";
+    /// let nmcli = Nmcli::new();
+    ///
+    /// let is_known_ssid = nmcli.is_known_ssid(ssid.as_bytes()).unwrap();
+    /// match is_known_ssid {
+    ///     true => println!("{} is a known SSID!", ssid),
+    ///     false => println!("{} is not a known SSID!", ssid),
+    /// };
+    /// ```
+    ///
+    /// [`NetworkAdapterError::CannotGetSSIDStatus`]: crate::NetworkAdapterError::CannotGetSSIDStatus
     fn is_known_ssid(&self, ssid: &[u8]) -> Result<bool, Error> {
         let args = ["-g", "NAME", "connection", "show"].map(|a| a.as_bytes());
 
@@ -196,6 +513,77 @@ impl Wl for Nmcli {
         Ok(exists)
     }
 
+    /// Connects to the given SSID.
+    ///
+    /// The output is in a **human-readable format** and may contain multiple lines.
+    ///
+    /// # Panics
+    ///
+    /// This method does not panic.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`NetworkAdapterError::CannotConnect`] if it fails to connect to the the SSID.
+    ///
+    /// # Examples
+    ///
+    /// To establish a new connection, provide both `ssid` and `passwd`.
+    ///
+    /// ```
+    /// use wl::{Nmcli,Wl};
+    /// use std::io::{self, Write};
+    ///
+    /// let ssid = "SSID";
+    /// let passwd = Some("PASS".as_bytes());
+    /// let is_known_ssid = false;
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let connect_result = nmcli.connect(ssid.as_bytes(), passwd, is_known_ssid);
+    ///
+    /// match connect_result {
+    ///     Ok(res) => io::stdout().write_all(&res).unwrap(),
+    ///     Err(err) => eprintln!("{}", err),
+    /// };
+    /// ```
+    ///
+    /// To re-use a connection from the known network list, only provide `ssid`.
+    ///
+    /// ```
+    /// use wl::{Nmcli,Wl};
+    /// use std::io::{self, Write};
+    ///
+    /// let ssid = "Known-SSID";
+    /// let passwd = None;
+    /// let is_known_ssid = true;
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let connect_result = nmcli.connect(ssid.as_bytes(), passwd, is_known_ssid);
+    ///
+    /// match connect_result {
+    ///     Ok(res) => io::stdout().write_all(&res).unwrap(),
+    ///     Err(err) => eprintln!("{}", err),
+    /// };
+    /// ```
+    ///
+    /// To "update" the connection from the known network list, provide all the arguments.
+    ///
+    /// ```
+    /// use wl::{Nmcli,Wl};
+    /// use std::io::{self, Write};
+    ///
+    /// let ssid = "Known-SSID";
+    /// let passwd = Some("NEW_PASS".as_bytes());
+    /// let is_known_ssid = true;
+    ///
+    /// let nmcli = Nmcli::new();
+    /// let connect_result = nmcli.connect(ssid.as_bytes(), passwd, is_known_ssid);
+    ///
+    /// match connect_result {
+    ///     Ok(res) => io::stdout().write_all(&res).unwrap(),
+    ///     Err(err) => eprintln!("{}", err),
+    /// };
+    /// ```
+    /// [`NetworkAdapterError::CannotConnect`]: crate::NetworkAdapterError::CannotConnect
     fn connect(
         &self,
         ssid: &[u8],

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -4,8 +4,13 @@ use crate::adapter::{self, Wl};
 use crate::api::ScanArgs;
 use crate::write_bytes;
 
+/// Defines [`Error`] variants that may return during a scan.
+///
+/// [`Error`]: std::error::Error
 #[derive(Debug)]
 pub enum Error {
+    /// Represents an invalid signal strength that cannot be used
+    /// to filter the scan list.
     InvalidSignalStrength(u8),
 }
 
@@ -22,6 +27,33 @@ impl fmt::Display for Error {
 }
 impl error::Error for Error {}
 
+/// Writes the list of the available WiFi networks. To see a list of the known WiFi networks, please refer to [`list_networks`] instead.
+///
+/// The list is retrieved by using a [`Wl`] implementation.
+/// The list is written to the provided [`io::Write`] implementation.
+///
+/// The default list format depends on the [`Wl`] implementation.
+/// [`ScanArgs`] is used to manipulate the list.
+///
+/// To see how [`ScanArgs`] manipulates the list, check out the network backend modules:
+///
+/// - nmcli: [`nmcli::scan`]
+///
+/// # Panics
+///
+/// This function does not panic.
+///
+/// # Errors
+///
+/// This function returns [`Error::InvalidSignalStrength`] if the provided signal strength is above 100.
+///
+/// This function can also return an [`NetworkAdapterError`] when the underlying [`Wl`] implementation fails or [`io::Error`] when the information cannot be written on the given [`io::Write`].
+///
+/// [`Error::InvalidSignalStrength`]: crate::scan::Error::InvalidSignalStrength
+/// [`nmcli::scan`]: crate::Nmcli::scan
+/// [`NetworkAdapterError`]: crate::adapter::Error
+/// [`io::Error`]: std::io::Error
+/// [`list_networks`]: crate::list_networks
 pub fn scan(f: &mut impl io::Write, args: ScanArgs) -> Result<(), Box<dyn error::Error>> {
     const MAX_SIGNAL_STRENGTH: u8 = 100u8;
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -5,6 +5,27 @@ use crate::{
     write_bytes,
 };
 
+/// Provides the WiFi status and connected SSID-Device pairs by using a [`Wl`] implementation.
+///
+/// The WiFi status and SSID-Device pairs are written to the stdout stream.
+///
+/// The format of the WiFi status depends on the [`Wl`] implementation.
+///
+/// The format of the SSID-Device pairs is like below:
+///
+/// `connected networks: SSID1/Dev1, SSID2/Dev2, ..., SSIDN/DevN`
+///
+/// # Panics
+///
+/// This function does not panic.
+///
+/// # Errors
+///
+/// This function can return an [`adapter::Error`] when the underlying [`Wl`] implementation fails or [`io::Error`] when the information cannot be written on the stdout stream.
+///
+/// [`Wl`]: crate::Wl
+/// [`adapter::Error`]: crate::adapter::Error
+/// [`io::Error`]: std::io::Error
 pub fn status() -> Result<(), Box<dyn error::Error>> {
     let mut stdout = io::stdout();
     let process = adapter::new();

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -5,6 +5,22 @@ use crate::{
     write_bytes,
 };
 
+/// Toggles the WiFi status by using a [`Wl`] implementation.
+///
+/// The latest WiFi status is written to the stdout stream.
+///
+/// The format of the WiFi status depends on the [`Wl`] implementation.
+///
+/// # Panics
+///
+/// This function does not panic.
+///
+/// # Errors
+///
+/// This function can return an [`adapter::Error`] when the underlying [`Wl`] implementation fails or [`io::Error`] when the information cannot be written on the stdout stream.
+///
+/// [`adapter::Error`]: crate::adapter::Error
+/// [`io::Error`]: std::io::Error
 pub fn toggle() -> Result<(), Box<dyn error::Error>> {
     let process = adapter::new();
     let toggled_status = process.toggle_wifi()?;


### PR DESCRIPTION
Doc comments are added for all public members of the `wl` library crate.

### Other Changes

1 - Whilst writing the documentation for the lib crate, it is noticed that the public lib crate API did not export most of the `adapter` module and the actual `Nmcli` struct as the default network backend. Therefore, to have a lib crate that can be used as a standalone module in the future, the API exports are updated accordingly.

2 - Namings of exported types are also updated for more clarity, which helps the goal above.